### PR TITLE
docs: translate lib modules and types to English

### DIFF
--- a/src/lib/__tests__/acp-error-handler.test.ts
+++ b/src/lib/__tests__/acp-error-handler.test.ts
@@ -9,88 +9,88 @@ describe("handleAcpError()", () => {
   });
 
   // --- AccessDeniedException ---
-  it("應辨識 AccessDeniedException 並回傳權限不足訊息", () => {
+  it("should identify AccessDeniedException and return an insufficient permissions message", () => {
     const raw = 'AccessDeniedException: User is not authorized to perform this action';
     const result = handleAcpError(raw);
 
     expect(result.isAcpError).toBe(true);
-    expect(result.userMessage).toBe("🔐 ACP 權限不足，請執行 device pairing。");
-    expect(result.fixSuggestions).toContain("請執行 `openclaw acp pair` 完成 device pairing");
+    expect(result.userMessage).toBe("🔐 Insufficient ACP permissions. Please perform device pairing.");
+    expect(result.fixSuggestions).toContain("Run `openclaw acp pair` to complete device pairing");
     expect(result.debugMessage).toBe(raw);
   });
 
-  it("AccessDeniedException 應不區分大小寫", () => {
+  it("AccessDeniedException should be case-insensitive", () => {
     const raw = 'accessdeniedexception: forbidden';
     const result = handleAcpError(raw);
 
     expect(result.isAcpError).toBe(true);
-    expect(result.userMessage).toContain("ACP 權限不足");
+    expect(result.userMessage).toContain("Insufficient ACP permissions");
   });
 
   // --- pairing required ---
-  it("應辨識 pairing required 並回傳 pairing 相關訊息", () => {
+  it("should identify pairing required and return a pairing-related message", () => {
     const raw = 'Error: pairing required for device xyz-123';
     const result = handleAcpError(raw);
 
     expect(result.isAcpError).toBe(true);
-    expect(result.userMessage).toBe("🔐 需要完成 device pairing，請參閱安裝指南。");
+    expect(result.userMessage).toBe("🔐 Device pairing required. Please refer to the installation guide.");
     expect(result.fixSuggestions.length).toBeGreaterThan(0);
     expect(result.debugMessage).toBe(raw);
   });
 
-  it("pairing required 應不區分大小寫", () => {
+  it("pairing required should be case-insensitive", () => {
     const raw = 'PAIRING REQUIRED';
     const result = handleAcpError(raw);
 
     expect(result.isAcpError).toBe(true);
-    expect(result.userMessage).toContain("device pairing");
+    expect(result.userMessage).toContain("Device pairing");
   });
 
-  // --- scope 相關 ---
-  it("應辨識 scope 關鍵字並回傳 scope 權限訊息", () => {
+  // --- scope related ---
+  it("should identify scope keyword and return a scope permissions message", () => {
     const raw = 'Error: insufficient scope permissions for acp:agent:invoke';
     const result = handleAcpError(raw);
 
     expect(result.isAcpError).toBe(true);
-    expect(result.userMessage).toContain("scope 權限不足");
+    expect(result.userMessage).toContain("scope permissions");
     expect(result.fixSuggestions.length).toBeGreaterThan(0);
   });
 
-  it("scope 關鍵字應作為獨立單詞比對", () => {
-    // "microscope" 不應觸發 scope 比對
+  it("scope keyword should match as a standalone word", () => {
+    // "microscope" should not trigger scope matching
     const raw = 'Error: microscope calibration failed';
     const result = handleAcpError(raw);
 
     expect(result.isAcpError).toBe(false);
   });
 
-  // --- 優先順序 ---
-  it("AccessDeniedException 應優先於 scope 比對", () => {
+  // --- Priority order ---
+  it("AccessDeniedException should take priority over scope matching", () => {
     const raw = 'AccessDeniedException: scope not granted';
     const result = handleAcpError(raw);
 
-    expect(result.userMessage).toContain("ACP 權限不足");
+    expect(result.userMessage).toContain("Insufficient ACP permissions");
   });
 
-  it("pairing required 應優先於 scope 比對", () => {
+  it("pairing required should take priority over scope matching", () => {
     const raw = 'pairing required: scope verification pending';
     const result = handleAcpError(raw);
 
-    expect(result.userMessage).toContain("device pairing");
+    expect(result.userMessage).toContain("Device pairing");
   });
 
-  // --- 無法辨識的錯誤 ---
-  it("無法辨識的錯誤應回傳通用 ACP 錯誤訊息", () => {
+  // --- Unrecognized errors ---
+  it("unrecognized errors should return a generic ACP error message", () => {
     const raw = 'Some completely unknown ACP error occurred';
     const result = handleAcpError(raw);
 
     expect(result.isAcpError).toBe(false);
     expect(result.userMessage).toContain("npm run validate");
-    expect(result.fixSuggestions).toContain("請執行 `npm run validate` 進行健康檢查");
+    expect(result.fixSuggestions).toContain("Run `npm run validate` for a health check");
   });
 
-  // --- stderr 記錄 ---
-  it("應將完整原始錯誤記錄至 stderr", () => {
+  // --- stderr logging ---
+  it("should log the full raw error to stderr", () => {
     const raw = 'AccessDeniedException: test error for logging';
     handleAcpError(raw);
 
@@ -99,7 +99,7 @@ describe("handleAcpError()", () => {
     );
   });
 
-  it("無法辨識的錯誤也應記錄至 stderr", () => {
+  it("unrecognized errors should also be logged to stderr", () => {
     const raw = 'Unknown error xyz';
     handleAcpError(raw);
 
@@ -108,8 +108,8 @@ describe("handleAcpError()", () => {
     );
   });
 
-  // --- 訊息長度 ---
-  it("所有回傳的 userMessage 長度應 ≤ 200 字元", () => {
+  // --- Message length ---
+  it("all returned userMessage lengths should be ≤ 200 characters", () => {
     const testCases = [
       "AccessDeniedException: test",
       "pairing required",

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { SkillConfig } from "../../types/index.js";
 
-// 儲存原始 env 以便每次測試後還原
+// Save original env to restore after each test
 const originalEnv = { ...process.env };
 
-// 動態 import 以確保每次測試都能讀取到最新的 process.env
+// Dynamic import to ensure each test reads the latest process.env
 async function importLoadConfig() {
-  // 清除模組快取，讓 dotenv.config() 與 process.env 重新讀取
+  // Clear module cache so dotenv.config() and process.env are re-read
   vi.resetModules();
   const mod = await import("../config.js");
   return mod.loadConfig;
@@ -14,7 +14,7 @@ async function importLoadConfig() {
 
 describe("loadConfig()", () => {
   beforeEach(() => {
-    // 清除所有相關環境變數，確保測試隔離
+    // Clear all related environment variables to ensure test isolation
     delete process.env.KIRO_AGENT_NAME;
     delete process.env.KIRO_TIMEOUT_MS;
     delete process.env.KIRO_WRAPPER_CMD;
@@ -24,11 +24,11 @@ describe("loadConfig()", () => {
   });
 
   afterEach(() => {
-    // 還原原始環境變數
+    // Restore original environment variables
     process.env = { ...originalEnv };
   });
 
-  it("應回傳所有欄位的預設值（未設定任何環境變數時）", async () => {
+  it("should return default values for all fields (when no env vars are set)", async () => {
     const loadConfig = await importLoadConfig();
     const config: SkillConfig = loadConfig();
 
@@ -40,7 +40,7 @@ describe("loadConfig()", () => {
     expect(config.debugMode).toBe(false);
   });
 
-  it("應使用環境變數覆寫預設值", async () => {
+  it("should override defaults with environment variables", async () => {
     process.env.KIRO_AGENT_NAME = "my-kiro";
     process.env.KIRO_TIMEOUT_MS = "60000";
     process.env.KIRO_WRAPPER_CMD = "custom-wrapper";
@@ -59,7 +59,7 @@ describe("loadConfig()", () => {
     expect(config.debugMode).toBe(true);
   });
 
-  it("KIRO_DEBUG 設為 '1' 時 debugMode 應為 true", async () => {
+  it("KIRO_DEBUG set to '1' should result in debugMode being true", async () => {
     process.env.KIRO_DEBUG = "1";
 
     const loadConfig = await importLoadConfig();
@@ -68,7 +68,7 @@ describe("loadConfig()", () => {
     expect(config.debugMode).toBe(true);
   });
 
-  it("KIRO_DEBUG 設為非 true/1 的值時 debugMode 應為 false", async () => {
+  it("KIRO_DEBUG set to non-true/1 value should result in debugMode being false", async () => {
     process.env.KIRO_DEBUG = "yes";
 
     const loadConfig = await importLoadConfig();
@@ -77,7 +77,7 @@ describe("loadConfig()", () => {
     expect(config.debugMode).toBe(false);
   });
 
-  it("ALLOWED_CHAT_IDS 含有空白時應正確 trim", async () => {
+  it("ALLOWED_CHAT_IDS with whitespace should be trimmed correctly", async () => {
     process.env.ALLOWED_CHAT_IDS = " 111 , 222 , 333 ";
 
     const loadConfig = await importLoadConfig();
@@ -86,7 +86,7 @@ describe("loadConfig()", () => {
     expect(config.allowedChatIds).toEqual(["111", "222", "333"]);
   });
 
-  it("KIRO_TIMEOUT_MS 為無效值時應拋出錯誤", async () => {
+  it("KIRO_TIMEOUT_MS with invalid value should throw an error", async () => {
     process.env.KIRO_TIMEOUT_MS = "not-a-number";
 
     const loadConfig = await importLoadConfig();
@@ -95,7 +95,7 @@ describe("loadConfig()", () => {
     expect(() => loadConfig()).toThrow("not-a-number");
   });
 
-  it("KIRO_TIMEOUT_MS 為負數時應拋出錯誤", async () => {
+  it("KIRO_TIMEOUT_MS with negative value should throw an error", async () => {
     process.env.KIRO_TIMEOUT_MS = "-5000";
 
     const loadConfig = await importLoadConfig();
@@ -103,7 +103,7 @@ describe("loadConfig()", () => {
     expect(() => loadConfig()).toThrow("KIRO_TIMEOUT_MS");
   });
 
-  it("KIRO_TIMEOUT_MS 為 0 時應拋出錯誤", async () => {
+  it("KIRO_TIMEOUT_MS with 0 should throw an error", async () => {
     process.env.KIRO_TIMEOUT_MS = "0";
 
     const loadConfig = await importLoadConfig();

--- a/src/lib/__tests__/error-formatter.test.ts
+++ b/src/lib/__tests__/error-formatter.test.ts
@@ -3,132 +3,132 @@ import { formatError, sanitize, ERROR_MAPPINGS } from "../error-formatter.js";
 
 describe("formatError()", () => {
   // --- JSON-RPC errors ---
-  it("應辨識 JSON-RPC -32603 (Internal error) 並回傳對應訊息", () => {
+  it("should identify JSON-RPC -32603 (Internal error) and return the corresponding message", () => {
     const raw = '{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Internal error","data":"something"}}';
     const result = formatError(raw, 1);
 
     expect(result.errorType).toBe("json_rpc");
-    expect(result.userMessage).toBe("⚠️ 服務內部錯誤，請稍後再試。");
+    expect(result.userMessage).toBe("⚠️ Internal service error. Please try again later.");
     expect(result.debugMessage).toBe(raw);
   });
 
-  it("應辨識 JSON-RPC -32600 (Invalid Request) 並回傳對應訊息", () => {
+  it("should identify JSON-RPC -32600 (Invalid Request) and return the corresponding message", () => {
     const raw = '{"code":-32600,"message":"Invalid Request"}';
     const result = formatError(raw, 1);
 
     expect(result.errorType).toBe("json_rpc");
-    expect(result.userMessage).toBe("⚠️ 請求格式錯誤，請重新嘗試。");
+    expect(result.userMessage).toBe("⚠️ Invalid request format. Please try again.");
   });
 
-  it("應辨識 JSON-RPC -32601 (Method not found) 並回傳對應訊息", () => {
+  it("should identify JSON-RPC -32601 (Method not found) and return the corresponding message", () => {
     const raw = '{"code":-32601,"message":"Method not found"}';
     const result = formatError(raw, 1);
 
     expect(result.errorType).toBe("json_rpc");
-    expect(result.userMessage).toBe("⚠️ 指定的服務方法不存在，請確認設定。");
+    expect(result.userMessage).toBe("⚠️ The specified service method does not exist. Please check the configuration.");
   });
 
   // --- Provider errors ---
-  it("應辨識 finish_reason: error 並回傳 provider 錯誤訊息", () => {
+  it("should identify finish_reason: error and return a provider error message", () => {
     const raw = 'Provider finish_reason: error - something went wrong';
     const result = formatError(raw, 1);
 
     expect(result.errorType).toBe("provider");
-    expect(result.userMessage).toBe("⚠️ AI 服務暫時無法回應，請稍後再試。");
+    expect(result.userMessage).toBe("⚠️ The AI service is temporarily unavailable. Please try again later.");
   });
 
-  it("應辨識 rate_limit 並回傳對應訊息", () => {
+  it("should identify rate_limit and return the corresponding message", () => {
     const raw = 'Error: rate_limit exceeded, please retry later';
     const result = formatError(raw, 1);
 
     expect(result.errorType).toBe("provider");
-    expect(result.userMessage).toBe("⚠️ AI 服務請求過於頻繁，請稍後再試。");
+    expect(result.userMessage).toBe("⚠️ AI service rate limit exceeded. Please try again later.");
   });
 
-  it("應辨識 context_length_exceeded 並回傳對應訊息", () => {
+  it("should identify context_length_exceeded and return the corresponding message", () => {
     const raw = 'Error: context_length_exceeded';
     const result = formatError(raw, 1);
 
     expect(result.errorType).toBe("provider");
-    expect(result.userMessage).toBe("⚠️ 訊息過長，請縮短後重試。");
+    expect(result.userMessage).toBe("⚠️ Message too long. Please shorten it and try again.");
   });
 
-  it("應辨識 model_not_found 並回傳對應訊息", () => {
+  it("should identify model_not_found and return the corresponding message", () => {
     const raw = 'Error: model_not_found: gpt-5-turbo';
     const result = formatError(raw, 1);
 
     expect(result.errorType).toBe("provider");
-    expect(result.userMessage).toBe("⚠️ AI 模型設定錯誤，請聯繫管理員。");
+    expect(result.userMessage).toBe("⚠️ AI model configuration error. Please contact the administrator.");
   });
 
   // --- ACP permission errors ---
-  it("應辨識 AccessDeniedException 並回傳 acp_permission 錯誤", () => {
+  it("should identify AccessDeniedException and return an acp_permission error", () => {
     const raw = 'AccessDeniedException: User is not authorized';
     const result = formatError(raw, 1);
 
     expect(result.errorType).toBe("acp_permission");
-    expect(result.userMessage).toBe("🔐 ACP 權限不足，請執行 device pairing。");
+    expect(result.userMessage).toBe("🔐 Insufficient ACP permissions. Please perform device pairing.");
   });
 
-  it("應辨識 pairing required 並回傳 acp_permission 錯誤", () => {
+  it("should identify pairing required and return an acp_permission error", () => {
     const raw = 'Error: pairing required for this device';
     const result = formatError(raw, 1);
 
     expect(result.errorType).toBe("acp_permission");
-    expect(result.userMessage).toBe("🔐 需要完成 device pairing，請參閱安裝指南。");
+    expect(result.userMessage).toBe("🔐 Device pairing required. Please refer to the installation guide.");
   });
 
   // --- Timeout ---
-  it("exit code 3 應回傳 timeout 錯誤（優先於 pattern 比對）", () => {
+  it("exit code 3 should return a timeout error (takes priority over pattern matching)", () => {
     const raw = "some random output without timeout keyword";
     const result = formatError(raw, 3);
 
     expect(result.errorType).toBe("timeout");
-    expect(result.userMessage).toBe("⏱️ Kiro 回應逾時，請稍後再試。");
+    expect(result.userMessage).toBe("⏱️ Kiro response timed out. Please try again later.");
   });
 
-  it("即使 rawOutput 包含其他錯誤模式，exit code 3 仍應回傳 timeout", () => {
+  it("even if rawOutput contains other error patterns, exit code 3 should still return timeout", () => {
     const raw = '{"code":-32603,"message":"Internal error"}';
     const result = formatError(raw, 3);
 
     expect(result.errorType).toBe("timeout");
-    expect(result.userMessage).toBe("⏱️ Kiro 回應逾時，請稍後再試。");
+    expect(result.userMessage).toBe("⏱️ Kiro response timed out. Please try again later.");
   });
 
-  it("rawOutput 包含 timeout 關鍵字時應回傳 timeout 錯誤", () => {
+  it("rawOutput containing timeout keyword should return a timeout error", () => {
     const raw = "Connection timed out after 120000ms";
     const result = formatError(raw, 1);
 
     expect(result.errorType).toBe("timeout");
-    expect(result.userMessage).toBe("⏱️ Kiro 回應逾時，請稍後再試。");
+    expect(result.userMessage).toBe("⏱️ Kiro response timed out. Please try again later.");
   });
 
   // --- Unknown errors ---
-  it("無法辨識的錯誤應回傳通用訊息", () => {
+  it("unrecognized errors should return a generic message", () => {
     const raw = "Something completely unexpected happened";
     const result = formatError(raw, 1);
 
     expect(result.errorType).toBe("unknown");
-    expect(result.userMessage).toBe("⚠️ Kiro 暫時無法處理您的請求，請稍後再試。");
+    expect(result.userMessage).toBe("⚠️ Kiro is temporarily unable to process your request. Please try again later.");
   });
 
   // --- Message length ---
-  it("所有 ERROR_MAPPINGS 的 userMessage 長度應 ≤ 200 字元", () => {
+  it("all ERROR_MAPPINGS userMessage lengths should be ≤ 200 characters", () => {
     for (const mapping of ERROR_MAPPINGS) {
       expect(mapping.userMessage.length).toBeLessThanOrEqual(200);
     }
   });
 
-  it("formatError 回傳的 userMessage 長度應 ≤ 200 字元", () => {
-    // 測試各種 exit code
+  it("formatError returned userMessage length should be ≤ 200 characters", () => {
+    // Test various exit codes
     for (const exitCode of [0, 1, 2, 3]) {
       const result = formatError("any error", exitCode);
       expect(result.userMessage.length).toBeLessThanOrEqual(200);
     }
   });
 
-  // --- debugMessage 保留原始輸出 ---
-  it("debugMessage 應保留完整的原始輸出", () => {
+  // --- debugMessage preserves raw output ---
+  it("debugMessage should preserve the complete raw output", () => {
     const raw = '{"code":-32603,"message":"Internal error","data":"secret-data","request_id":"abc-123"}';
     const result = formatError(raw, 1);
 
@@ -137,7 +137,7 @@ describe("formatError()", () => {
 });
 
 describe("sanitize()", () => {
-  it("應移除 request_id 欄位", () => {
+  it("should remove request_id fields", () => {
     const input = 'Error occurred. request_id: abc-123-def, details: something';
     const result = sanitize(input);
 
@@ -145,7 +145,7 @@ describe("sanitize()", () => {
     expect(result).not.toContain("abc-123-def");
   });
 
-  it("應移除 JSON 格式的 request_id", () => {
+  it("should remove JSON-formatted request_id", () => {
     const input = '{"error":"bad","request_id":"req-456","code":500}';
     const result = sanitize(input);
 
@@ -153,7 +153,7 @@ describe("sanitize()", () => {
     expect(result).not.toContain("req-456");
   });
 
-  it("應移除 stack trace 行", () => {
+  it("should remove stack trace lines", () => {
     const input = `Error: something failed
     at Object.<anonymous> (/app/src/index.ts:10:5)
     at Module._compile (node:internal/modules/cjs/loader:1234:14)
@@ -165,7 +165,7 @@ describe("sanitize()", () => {
     expect(result).not.toContain("at processTicksAndRejections");
   });
 
-  it("應移除內部端點 URL", () => {
+  it("should remove internal endpoint URLs", () => {
     const input = "Failed to connect to https://internal-api.example.com/v1/chat endpoint";
     const result = sanitize(input);
 
@@ -173,7 +173,7 @@ describe("sanitize()", () => {
     expect(result).toContain("[redacted-url]");
   });
 
-  it("應移除 http URL", () => {
+  it("should remove http URLs", () => {
     const input = "Connecting to http://localhost:3000/api/health";
     const result = sanitize(input);
 
@@ -181,7 +181,7 @@ describe("sanitize()", () => {
     expect(result).toContain("[redacted-url]");
   });
 
-  it("應移除常見 Error 類型標頭", () => {
+  it("should remove common Error type headers", () => {
     const input = `TypeError: Cannot read property 'foo' of undefined
     at bar (/app/src/bar.ts:5:3)`;
     const result = sanitize(input);
@@ -190,14 +190,14 @@ describe("sanitize()", () => {
     expect(result).not.toContain("at bar");
   });
 
-  it("不含敏感資訊的訊息應保持不變", () => {
-    const input = "一般錯誤訊息，沒有敏感資訊";
+  it("messages without sensitive information should remain unchanged", () => {
+    const input = "A general error message with no sensitive info";
     const result = sanitize(input);
 
     expect(result).toBe(input);
   });
 
-  it("應清理多餘的空行", () => {
+  it("should clean up excessive blank lines", () => {
     const input = "Line 1\n\n\n\n\nLine 2";
     const result = sanitize(input);
 

--- a/src/lib/__tests__/reply-suppressor.test.ts
+++ b/src/lib/__tests__/reply-suppressor.test.ts
@@ -6,7 +6,7 @@ describe("Reply Suppressor", () => {
 
   beforeEach(() => {
     stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    // 使用 fake timers 控制時間
+    // Use fake timers to control time
     vi.useFakeTimers();
   });
 
@@ -15,84 +15,84 @@ describe("Reply Suppressor", () => {
     vi.restoreAllMocks();
   });
 
-  // --- markSession → shouldCancel 正常流程 ---
-  describe("markSession() → shouldCancel() 正常流程", () => {
-    it("標記後 shouldCancel 應回傳 true", () => {
+  // --- markSession → shouldCancel normal flow ---
+  describe("markSession() → shouldCancel() normal flow", () => {
+    it("shouldCancel should return true after marking", () => {
       const key = "test-session-1";
       markSession(key);
       expect(shouldCancel(key)).toBe(true);
     });
 
-    it("未標記的 session shouldCancel 應回傳 false", () => {
+    it("shouldCancel should return false for unmarked sessions", () => {
       expect(shouldCancel("non-existent-session")).toBe(false);
     });
 
-    it("markSession 應為同步操作（不回傳 Promise）", () => {
+    it("markSession should be a synchronous operation (does not return a Promise)", () => {
       const result = markSession("sync-test");
       expect(result).toBeUndefined();
     });
   });
 
-  // --- TTL 過期 ---
-  describe("TTL 過期行為", () => {
-    it("TTL 30 秒過期後 shouldCancel 應回傳 false", () => {
+  // --- TTL expiration ---
+  describe("TTL expiration behavior", () => {
+    it("shouldCancel should return false after 30-second TTL expires", () => {
       const key = "ttl-test-session";
       markSession(key);
 
-      // 前進 30 秒（TTL 邊界）
+      // Advance 30 seconds (TTL boundary)
       vi.advanceTimersByTime(30_000);
 
       expect(shouldCancel(key)).toBe(false);
     });
 
-    it("TTL 未過期時 shouldCancel 應回傳 true", () => {
+    it("shouldCancel should return true when TTL has not expired", () => {
       const key = "ttl-not-expired";
       markSession(key);
 
-      // 前進 29 秒（未過期）
+      // Advance 29 seconds (not expired)
       vi.advanceTimersByTime(29_999);
 
       expect(shouldCancel(key)).toBe(true);
     });
   });
 
-  // --- 消費後標記清除 ---
-  describe("shouldCancel 消費後標記清除", () => {
-    it("shouldCancel 消費後再次呼叫應回傳 false", () => {
+  // --- Mark cleared after consumption ---
+  describe("shouldCancel mark cleared after consumption", () => {
+    it("shouldCancel should return false on second call after consumption", () => {
       const key = "consume-test";
       markSession(key);
 
-      // 第一次消費
+      // First consumption
       expect(shouldCancel(key)).toBe(true);
-      // 第二次應回傳 false（已被消費）
+      // Second should return false (already consumed)
       expect(shouldCancel(key)).toBe(false);
     });
   });
 
-  // --- 多 session 獨立性 ---
-  describe("多 session 獨立性", () => {
-    it("不同 session key 應互不影響", () => {
+  // --- Multi-session independence ---
+  describe("Multi-session independence", () => {
+    it("different session keys should not affect each other", () => {
       markSession("session-a");
       markSession("session-b");
 
       expect(shouldCancel("session-a")).toBe(true);
       expect(shouldCancel("session-b")).toBe(true);
-      // 兩者都已消費
+      // Both consumed
       expect(shouldCancel("session-a")).toBe(false);
       expect(shouldCancel("session-b")).toBe(false);
     });
   });
 
-  // --- stderr 日誌記錄 ---
-  describe("stderr 日誌記錄", () => {
-    it("markSession 應記錄至 stderr", () => {
+  // --- stderr logging ---
+  describe("stderr logging", () => {
+    it("markSession should log to stderr", () => {
       markSession("log-test");
       expect(stderrSpy).toHaveBeenCalledWith(
         expect.stringContaining('marked session="log-test"'),
       );
     });
 
-    it("shouldCancel 取消時應記錄至 stderr", () => {
+    it("shouldCancel cancellation should log to stderr", () => {
       markSession("cancel-log-test");
       shouldCancel("cancel-log-test");
       expect(stderrSpy).toHaveBeenCalledWith(
@@ -103,7 +103,7 @@ describe("Reply Suppressor", () => {
 
   // --- getRecentLogs ---
   describe("getRecentLogs()", () => {
-    it("應回傳最近的操作日誌", () => {
+    it("should return recent operation logs", () => {
       markSession("log-a");
       markSession("log-b");
       shouldCancel("log-a");
@@ -116,8 +116,8 @@ describe("Reply Suppressor", () => {
       expect(actions).toContain("cancelled");
     });
 
-    it("預設回傳最多 10 筆日誌", () => {
-      // 產生超過 10 筆日誌
+    it("should return at most 10 log entries by default", () => {
+      // Generate more than 10 log entries
       for (let i = 0; i < 15; i++) {
         markSession(`bulk-${i}`);
       }
@@ -126,7 +126,7 @@ describe("Reply Suppressor", () => {
       expect(recentLogs.length).toBeLessThanOrEqual(10);
     });
 
-    it("指定 count 應限制回傳筆數", () => {
+    it("specifying count should limit the number of returned entries", () => {
       for (let i = 0; i < 5; i++) {
         markSession(`count-${i}`);
       }

--- a/src/lib/__tests__/session-isolator.test.ts
+++ b/src/lib/__tests__/session-isolator.test.ts
@@ -4,7 +4,7 @@ import { getKiroSessionId, getIsolationLimitations } from "../session-isolator.j
 describe("Session Isolator", () => {
   // --- getKiroSessionId ---
   describe("getKiroSessionId()", () => {
-    it("同一 chatId 應產生相同的 session ID", () => {
+    it("same chatId should produce the same session ID", () => {
       const chatId = "12345678";
       const id1 = getKiroSessionId(chatId);
       const id2 = getKiroSessionId(chatId);
@@ -12,26 +12,26 @@ describe("Session Isolator", () => {
       expect(id1).toBe(id2);
     });
 
-    it("不同 chatId 應產生不同的 session ID", () => {
+    it("different chatIds should produce different session IDs", () => {
       const id1 = getKiroSessionId("11111111");
       const id2 = getKiroSessionId("22222222");
 
       expect(id1).not.toBe(id2);
     });
 
-    it("session ID 格式應為 kiro-telegram-{chatId}", () => {
+    it("session ID format should be kiro-telegram-{chatId}", () => {
       const chatId = "99887766";
       const sessionId = getKiroSessionId(chatId);
 
       expect(sessionId).toBe(`kiro-telegram-${chatId}`);
     });
 
-    it("應正確處理數字字串 chatId", () => {
+    it("should correctly handle numeric string chatId", () => {
       const sessionId = getKiroSessionId("42");
       expect(sessionId).toBe("kiro-telegram-42");
     });
 
-    it("session ID 命名空間應與主 agent session key 不同", () => {
+    it("session ID namespace should differ from the main agent session key", () => {
       const chatId = "12345678";
       const kiroSessionId = getKiroSessionId(chatId);
       const mainAgentSessionKey = `agent:main:telegram:direct:${chatId}`;
@@ -43,14 +43,14 @@ describe("Session Isolator", () => {
 
   // --- getIsolationLimitations ---
   describe("getIsolationLimitations()", () => {
-    it("應回傳非空的限制陣列", () => {
+    it("should return a non-empty limitations array", () => {
       const limitations = getIsolationLimitations();
 
       expect(Array.isArray(limitations)).toBe(true);
       expect(limitations.length).toBeGreaterThan(0);
     });
 
-    it("每個限制應為非空字串", () => {
+    it("each limitation should be a non-empty string", () => {
       const limitations = getIsolationLimitations();
 
       for (const limitation of limitations) {
@@ -59,14 +59,14 @@ describe("Session Isolator", () => {
       }
     });
 
-    it("應提及 hook 機制的限制", () => {
+    it("should mention hook mechanism limitations", () => {
       const limitations = getIsolationLimitations();
       const combined = limitations.join(" ");
 
       expect(combined).toContain("hook");
     });
 
-    it("應提及 SOUL.md 替代方案", () => {
+    it("should mention SOUL.md alternative", () => {
       const limitations = getIsolationLimitations();
       const combined = limitations.join(" ");
 

--- a/src/lib/acp-error-handler.ts
+++ b/src/lib/acp-error-handler.ts
@@ -1,36 +1,36 @@
 // ============================================================
-// ACP Error Handler — 處理 ACP 層級的權限與連線錯誤
-// 對應需求: 14.1, 14.2, 14.3, 14.4, 14.5
+// ACP Error Handler — Handle ACP-level permission and connection errors
+// Requirements: 14.1, 14.2, 14.3, 14.4, 14.5
 // ============================================================
 
 import type { AcpErrorResult } from "../types/index.js";
 
 /**
- * 辨識 ACP 權限相關錯誤並產生修復建議。
+ * Identify ACP permission-related errors and generate fix suggestions.
  *
- * 處理順序：
- * 1. AccessDeniedException → 建議執行 `openclaw acp pair`
- * 2. pairing required → 建議檢查 pairing 狀態
- * 3. scope 相關關鍵字 → 建議檢查 scope 權限
- * 4. 無法辨識 → 通用 ACP 錯誤訊息，建議執行 `npm run validate`
+ * Processing order:
+ * 1. AccessDeniedException → suggest running `openclaw acp pair`
+ * 2. pairing required → suggest checking pairing status
+ * 3. scope-related keywords → suggest checking scope permissions
+ * 4. Unrecognized → generic ACP error message, suggest running `npm run validate`
  *
- * 所有情況皆將完整原始錯誤記錄至 stderr。
+ * In all cases, the full raw error is logged to stderr.
  *
- * @param rawError - ACP Wrapper 回傳的原始錯誤訊息
- * @returns AcpErrorResult 包含辨識結果、使用者訊息與修復建議
+ * @param rawError - Raw error message returned by the ACP Wrapper
+ * @returns AcpErrorResult containing identification result, user message, and fix suggestions
  */
 export function handleAcpError(rawError: string): AcpErrorResult {
-  // 完整原始錯誤記錄至 stderr
+  // Log full raw error to stderr
   process.stderr.write(`[ACP Error] Raw error: ${rawError}\n`);
 
   // 1. AccessDeniedException
   if (/AccessDeniedException/i.test(rawError)) {
     return {
       isAcpError: true,
-      userMessage: "🔐 ACP 權限不足，請執行 device pairing。",
+      userMessage: "🔐 Insufficient ACP permissions. Please perform device pairing.",
       fixSuggestions: [
-        "請執行 `openclaw acp pair` 完成 device pairing",
-        "完成後請確認已核准所需的 scope 權限",
+        "Run `openclaw acp pair` to complete device pairing",
+        "After completion, confirm the required scope permissions have been approved",
       ],
       debugMessage: rawError,
     };
@@ -40,37 +40,37 @@ export function handleAcpError(rawError: string): AcpErrorResult {
   if (/pairing\s+required/i.test(rawError)) {
     return {
       isAcpError: true,
-      userMessage: "🔐 需要完成 device pairing，請參閱安裝指南。",
+      userMessage: "🔐 Device pairing required. Please refer to the installation guide.",
       fixSuggestions: [
-        "請檢查 device pairing 狀態：`openclaw acp status`",
-        "若尚未 pairing，請執行 `openclaw acp pair`",
-        "詳細步驟請參閱 INSTALL.md 的 ACP Device Pairing 章節",
+        "Check device pairing status: `openclaw acp status`",
+        "If not yet paired, run `openclaw acp pair`",
+        "For detailed steps, see the ACP Device Pairing section in INSTALL.md",
       ],
       debugMessage: rawError,
     };
   }
 
-  // 3. scope 相關關鍵字
+  // 3. scope-related keywords
   if (/\bscope\b/i.test(rawError)) {
     return {
       isAcpError: true,
-      userMessage: "🔐 ACP scope 權限不足，請確認已核准所需權限。",
+      userMessage: "🔐 Insufficient ACP scope permissions. Please confirm the required permissions have been approved.",
       fixSuggestions: [
-        "請確認已核准所需的 scope 權限",
-        "可執行 `openclaw acp status` 查看目前已核准的 scopes",
-        "若需新增 scope，請重新執行 `openclaw acp pair`",
+        "Confirm the required scope permissions have been approved",
+        "Run `openclaw acp status` to view currently approved scopes",
+        "If additional scopes are needed, re-run `openclaw acp pair`",
       ],
       debugMessage: rawError,
     };
   }
 
-  // 4. 無法辨識 → 通用 ACP 錯誤
+  // 4. Unrecognized → generic ACP error
   return {
     isAcpError: false,
-    userMessage: "⚠️ ACP 發生未預期的錯誤，請執行 `npm run validate` 進行健康檢查。",
+    userMessage: "⚠️ An unexpected ACP error occurred. Please run `npm run validate` for a health check.",
     fixSuggestions: [
-      "請執行 `npm run validate` 進行健康檢查",
-      "若問題持續，請檢查 `openclaw acp` 是否正常運作",
+      "Run `npm run validate` for a health check",
+      "If the issue persists, check whether `openclaw acp` is working properly",
     ],
     debugMessage: rawError,
   };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,14 +1,15 @@
 import dotenv from "dotenv";
 import type { SkillConfig } from "../types/index.js";
 
-// 載入 .env 檔案中的環境變數
+// Load environment variables from .env file
 dotenv.config();
 
 /**
- * 從環境變數載入設定，驗證必要欄位，回傳型別安全的設定物件。
- * 缺少必要變數時拋出含明確訊息的錯誤。
+ * Load configuration from environment variables, validate required fields,
+ * and return a type-safe configuration object.
+ * Throws an error with a clear message when required variables are missing.
  *
- * 對應需求: 4.3, 4.4
+ * Requirements: 4.3, 4.4
  */
 export function loadConfig(): SkillConfig {
   const env = process.env;
@@ -19,7 +20,7 @@ export function loadConfig(): SkillConfig {
   const kiroTimeoutMs = Number(rawTimeout);
   if (Number.isNaN(kiroTimeoutMs) || kiroTimeoutMs <= 0) {
     throw new Error(
-      `環境變數 KIRO_TIMEOUT_MS 的值 "${rawTimeout}" 不是有效的正整數。請設定為毫秒數，例如 120000。`,
+      `The value "${rawTimeout}" for environment variable KIRO_TIMEOUT_MS is not a valid positive integer. Please set it to a millisecond value, e.g. 120000.`,
     );
   }
 

--- a/src/lib/error-formatter.ts
+++ b/src/lib/error-formatter.ts
@@ -1,106 +1,106 @@
 // ============================================================
-// Error Formatter — 將原始技術錯誤轉換為使用者友善的訊息
-// 對應需求: 11.1, 11.2, 11.3, 11.4, 11.5, 15.1, 15.2, 15.3
+// Error Formatter — Convert raw technical errors to user-friendly messages
+// Requirements: 11.1, 11.2, 11.3, 11.4, 11.5, 15.1, 15.2, 15.3
 // ============================================================
 
 import type { ErrorMapping, ErrorType, FormattedError } from "../types/index.js";
 
-/** 使用者訊息最大長度 */
+/** Maximum length for user messages */
 const MAX_USER_MESSAGE_LENGTH = 200;
 
 /**
- * 錯誤代碼對應表，按優先順序比對。
- * 涵蓋 JSON-RPC errors、provider errors、timeout、ACP permission、unknown。
+ * Error code mapping table, matched in priority order.
+ * Covers JSON-RPC errors, provider errors, timeout, ACP permission, and unknown.
  */
 export const ERROR_MAPPINGS: ErrorMapping[] = [
   // --- JSON-RPC errors ---
   {
     pattern: /"code"\s*:\s*-32603/,
     errorType: "json_rpc",
-    userMessage: "⚠️ 服務內部錯誤，請稍後再試。",
+    userMessage: "⚠️ Internal service error. Please try again later.",
   },
   {
     pattern: /"code"\s*:\s*-32600/,
     errorType: "json_rpc",
-    userMessage: "⚠️ 請求格式錯誤，請重新嘗試。",
+    userMessage: "⚠️ Invalid request format. Please try again.",
   },
   {
     pattern: /"code"\s*:\s*-32601/,
     errorType: "json_rpc",
-    userMessage: "⚠️ 指定的服務方法不存在，請確認設定。",
+    userMessage: "⚠️ The specified service method does not exist. Please check the configuration.",
   },
   // --- Provider errors ---
   {
     pattern: /finish_reason\s*:\s*error|finish_reason.*error/i,
     errorType: "provider",
-    userMessage: "⚠️ AI 服務暫時無法回應，請稍後再試。",
+    userMessage: "⚠️ The AI service is temporarily unavailable. Please try again later.",
   },
   {
     pattern: /rate_limit/i,
     errorType: "provider",
-    userMessage: "⚠️ AI 服務請求過於頻繁，請稍後再試。",
+    userMessage: "⚠️ AI service rate limit exceeded. Please try again later.",
   },
   {
     pattern: /context_length_exceeded/i,
     errorType: "provider",
-    userMessage: "⚠️ 訊息過長，請縮短後重試。",
+    userMessage: "⚠️ Message too long. Please shorten it and try again.",
   },
   {
     pattern: /model_not_found/i,
     errorType: "provider",
-    userMessage: "⚠️ AI 模型設定錯誤，請聯繫管理員。",
+    userMessage: "⚠️ AI model configuration error. Please contact the administrator.",
   },
   // --- ACP permission errors ---
   {
     pattern: /AccessDeniedException/i,
     errorType: "acp_permission",
-    userMessage: "🔐 ACP 權限不足，請執行 device pairing。",
+    userMessage: "🔐 Insufficient ACP permissions. Please perform device pairing.",
   },
   {
     pattern: /pairing required/i,
     errorType: "acp_permission",
-    userMessage: "🔐 需要完成 device pairing，請參閱安裝指南。",
+    userMessage: "🔐 Device pairing required. Please refer to the installation guide.",
   },
   // --- Timeout (exit code 3 handled in formatError) ---
   {
     pattern: /timeout|timed?\s*out/i,
     errorType: "timeout",
-    userMessage: "⏱️ Kiro 回應逾時，請稍後再試。",
+    userMessage: "⏱️ Kiro response timed out. Please try again later.",
   },
 ];
 
-/** 通用未知錯誤訊息 */
-const UNKNOWN_ERROR_MESSAGE = "⚠️ Kiro 暫時無法處理您的請求，請稍後再試。";
+/** Generic unknown error message */
+const UNKNOWN_ERROR_MESSAGE = "⚠️ Kiro is temporarily unable to process your request. Please try again later.";
 
-/** Timeout 錯誤訊息 */
-const TIMEOUT_ERROR_MESSAGE = "⏱️ Kiro 回應逾時，請稍後再試。";
+/** Timeout error message */
+const TIMEOUT_ERROR_MESSAGE = "⏱️ Kiro response timed out. Please try again later.";
 
 /**
- * 移除敏感資訊：request_id、stack trace、內部端點等。
+ * Remove sensitive information: request_id, stack traces, internal endpoints, etc.
  */
 export function sanitize(message: string): string {
   let result = message;
 
-  // 移除 request_id（各種格式）
+  // Remove request_id (various formats)
   result = result.replace(/["']?request_id["']?\s*[:=]\s*["']?[a-zA-Z0-9\-_]+["']?,?\s*/gi, "");
 
-  // 移除 stack trace（以 "at " 開頭的行）
+  // Remove stack trace lines (lines starting with "at ")
   result = result.replace(/^\s*at\s+.+$/gm, "");
 
-  // 移除常見 stack trace 標頭
+  // Remove common stack trace headers
   result = result.replace(/^(Error|TypeError|ReferenceError|SyntaxError|RangeError):.*\n?/gm, "");
 
-  // 移除內部端點 URL（http/https 開頭的 URL）
+  // Remove internal endpoint URLs (http/https URLs)
   result = result.replace(/https?:\/\/[^\s"',)}\]]+/gi, "[redacted-url]");
 
-  // 移除連續空行
+  // Remove consecutive blank lines
   result = result.replace(/\n{3,}/g, "\n\n");
 
   return result.trim();
 }
 
 /**
- * 確保訊息長度不超過上限，超過時截斷並加上省略號。
+ * Ensure message length does not exceed the limit; truncate with ellipsis if it does.
  */
 function truncateMessage(message: string, maxLength: number = MAX_USER_MESSAGE_LENGTH): string {
   if (message.length <= maxLength) {
@@ -110,16 +110,16 @@ function truncateMessage(message: string, maxLength: number = MAX_USER_MESSAGE_L
 }
 
 /**
- * 解析 ACP Wrapper 的 stdout/stderr 輸出，辨識錯誤類型並格式化。
+ * Parse ACP Wrapper stdout/stderr output, identify error type, and format.
  *
- * @param rawOutput - ACP Wrapper 的原始輸出（stdout + stderr）
- * @param exitCode - ACP Wrapper 的 exit code（0=成功, 1=usage, 2=連線失敗, 3=timeout）
- * @returns FormattedError 包含使用者訊息、除錯訊息與錯誤分類
+ * @param rawOutput - Raw output from the ACP Wrapper (stdout + stderr)
+ * @param exitCode - ACP Wrapper exit code (0=success, 1=usage, 2=connection failure, 3=timeout)
+ * @returns FormattedError containing user message, debug message, and error classification
  */
 export function formatError(rawOutput: string, exitCode: number): FormattedError {
   const debugMessage = rawOutput;
 
-  // 優先處理 exit code 3（timeout）
+  // Prioritize exit code 3 (timeout)
   if (exitCode === 3) {
     return {
       userMessage: truncateMessage(TIMEOUT_ERROR_MESSAGE),
@@ -128,7 +128,7 @@ export function formatError(rawOutput: string, exitCode: number): FormattedError
     };
   }
 
-  // 依序比對錯誤對應表
+  // Match against error mapping table in order
   for (const mapping of ERROR_MAPPINGS) {
     if (mapping.pattern.test(rawOutput)) {
       return {
@@ -139,7 +139,7 @@ export function formatError(rawOutput: string, exitCode: number): FormattedError
     }
   }
 
-  // 無法辨識的錯誤 → 通用訊息
+  // Unrecognized error → generic message
   return {
     userMessage: truncateMessage(UNKNOWN_ERROR_MESSAGE),
     debugMessage,

--- a/src/lib/reply-suppressor.ts
+++ b/src/lib/reply-suppressor.ts
@@ -1,39 +1,39 @@
 // ============================================================
-// Reply Suppressor — 管理 pending session 標記，確保 message:sending
-// hook 能可靠地取消主 agent 回覆
-// 對應需求: 12.1, 12.2, 12.3, 12.4, 12.5
+// Reply Suppressor — Manage pending session marks to ensure the message:sending
+// hook can reliably cancel the main agent reply
+// Requirements: 12.1, 12.2, 12.3, 12.4, 12.5
 // ============================================================
 
 import type { SuppressionLog } from "../types/index.js";
 
-/** TTL 預設 30 秒（毫秒） */
+/** Default TTL: 30 seconds (milliseconds) */
 const DEFAULT_TTL_MS = 30_000;
 
-/** 最大日誌保留筆數 */
+/** Maximum log entries to retain */
 const MAX_LOG_ENTRIES = 100;
 
 /**
- * 儲存 session key → 標記時間戳記（Date.now()）。
- * 使用 Map 確保 O(1) 查詢與刪除。
+ * Store session key → mark timestamp (Date.now()).
+ * Uses Map for O(1) lookup and deletion.
  */
 const sessionStore: Map<string, number> = new Map();
 
-/** 操作日誌（環形緩衝區，最多保留 MAX_LOG_ENTRIES 筆） */
+/** Operation log (ring buffer, retains up to MAX_LOG_ENTRIES) */
 const logs: SuppressionLog[] = [];
 
 /**
- * 將日誌寫入 stderr 並加入內部日誌陣列。
+ * Write log to stderr and add to the internal log array.
  */
 function addLog(sessionKey: string, action: SuppressionLog["action"]): void {
   const timestamp = Date.now();
   const entry: SuppressionLog = { sessionKey, timestamp, action };
 
-  // 記錄至 stderr（含 session key 與時間戳記）
+  // Log to stderr (with session key and timestamp)
   process.stderr.write(
     `[ReplySuppressor] ${action} session="${sessionKey}" at=${timestamp}\n`,
   );
 
-  // 維持日誌上限
+  // Maintain log size limit
   if (logs.length >= MAX_LOG_ENTRIES) {
     logs.shift();
   }
@@ -41,7 +41,7 @@ function addLog(sessionKey: string, action: SuppressionLog["action"]): void {
 }
 
 /**
- * 清除過期的 session 標記（TTL 已超過 DEFAULT_TTL_MS）。
+ * Purge expired session marks (TTL has exceeded DEFAULT_TTL_MS).
  */
 function purgeExpired(): void {
   const now = Date.now();
@@ -54,10 +54,11 @@ function purgeExpired(): void {
 }
 
 /**
- * 標記 session 為 pending（在 message:received 階段呼叫）。
+ * Mark a session as pending (called during the message:received phase).
  *
- * 此為同步操作，確保標記在任何 async 操作（如 ACP Wrapper 呼叫）之前完成，
- * 避免 message:sending hook 因時序問題而遺失取消訊號。
+ * This is a synchronous operation to ensure the mark is set before any async
+ * operations (such as ACP Wrapper calls), preventing the message:sending hook
+ * from missing the cancel signal due to timing issues.
  */
 export function markSession(sessionKey: string): void {
   purgeExpired();
@@ -66,12 +67,13 @@ export function markSession(sessionKey: string): void {
 }
 
 /**
- * 檢查並消費 session 標記（在 message:sending 階段呼叫）。
+ * Check and consume a session mark (called during the message:sending phase).
  *
- * 回傳 true 表示應取消主 agent 回覆（回傳 `{ cancel: true }`）。
- * 消費後標記會被清除，避免影響後續非 `/kiro` 訊息的正常處理。
+ * Returns true if the main agent reply should be cancelled (return `{ cancel: true }`).
+ * After consumption, the mark is cleared to avoid affecting subsequent non-`/kiro`
+ * messages' normal processing.
  *
- * @returns true 若 session 已標記且未過期，false 否則
+ * @returns true if the session is marked and not expired, false otherwise
  */
 export function shouldCancel(sessionKey: string): boolean {
   purgeExpired();
@@ -81,24 +83,24 @@ export function shouldCancel(sessionKey: string): boolean {
     return false;
   }
 
-  // 檢查是否在 TTL 內
+  // Check if within TTL
   if (Date.now() - markedAt >= DEFAULT_TTL_MS) {
     sessionStore.delete(sessionKey);
     addLog(sessionKey, "expired");
     return false;
   }
 
-  // 消費標記（一次性使用）
+  // Consume the mark (one-time use)
   sessionStore.delete(sessionKey);
   addLog(sessionKey, "cancelled");
   return true;
 }
 
 /**
- * 取得最近的抑制操作日誌供除錯使用。
+ * Get recent suppression operation logs for debugging.
  *
- * @param count - 回傳的日誌筆數，預設 10
- * @returns 最近的 SuppressionLog 陣列（由舊到新）
+ * @param count - Number of log entries to return, default 10
+ * @returns Array of recent SuppressionLog entries (oldest to newest)
  */
 export function getRecentLogs(count: number = 10): SuppressionLog[] {
   const start = Math.max(0, logs.length - count);

--- a/src/lib/session-isolator.ts
+++ b/src/lib/session-isolator.ts
@@ -1,45 +1,48 @@
 // ============================================================
-// Session Isolator — 確保 /kiro 訊息不洩漏至主 agent 的對話 context，
-// 並為每個 Telegram 使用者維護固定的 Kiro session ID 以實現跨訊息記憶
-// 對應需求: 13.1, 13.2, 13.5
+// Session Isolator — Ensure /kiro messages do not leak into the main agent's
+// conversation context, and maintain a fixed Kiro session ID per Telegram user
+// to enable cross-message memory
+// Requirements: 13.1, 13.2, 13.5
 // ============================================================
 
-/** Session ID 前綴，與主 agent 的 session key 命名空間完全分離 */
+/** Session ID prefix, completely separated from the main agent's session key namespace */
 const SESSION_PREFIX = "kiro-telegram-";
 
 /**
- * 根據 Telegram chat ID 產生固定的 Kiro session ID。
+ * Generate a fixed Kiro session ID based on the Telegram chat ID.
  *
- * 同一個 chat ID 永遠對應同一個 session，讓 kiro-cli 能記住對話歷史。
- * 格式：`kiro-telegram-{chatId}`
+ * The same chat ID always maps to the same session, allowing kiro-cli to
+ * remember conversation history.
+ * Format: `kiro-telegram-{chatId}`
  *
- * 此命名空間與 OpenClaw 主 agent 的 session key
- * （`agent:main:telegram:direct:{chatId}`）完全不同，不會互相干擾。
+ * This namespace is completely different from the OpenClaw main agent's session key
+ * (`agent:main:telegram:direct:{chatId}`), so they do not interfere with each other.
  *
  * @param chatId - Telegram chat ID
- * @returns 固定格式的 Kiro session ID
+ * @returns Fixed-format Kiro session ID
  */
 export function getKiroSessionId(chatId: string): string {
   return `${SESSION_PREFIX}${chatId}`;
 }
 
 /**
- * 記錄 OpenClaw hook 機制對 session 隔離的已知限制。
+ * Document the known limitations of the OpenClaw hook mechanism for session isolation.
  *
- * 這些限制源自 OpenClaw 平台的 hook 架構設計，無法在 skill 層級完全解決，
- * 但已在 INSTALL.md 中記錄並提供替代方案。
+ * These limitations stem from the OpenClaw platform's hook architecture design and
+ * cannot be fully resolved at the skill level. They are documented in INSTALL.md
+ * with alternative solutions provided.
  *
- * @returns 已知限制的字串陣列
+ * @returns Array of known limitation strings
  */
 export function getIsolationLimitations(): string[] {
   return [
-    "OpenClaw 的 message:received hook 無法阻止訊息進入主 agent 的 context window，" +
-      "/kiro 訊息內容可能仍會被主 agent 看到。",
-    "建議在 SOUL.md 中加入指令，要求主 agent 忽略以 /kiro 開頭的訊息，" +
-      "作為 hook 層級隔離的補充方案。",
-    "kiro-cli 重啟後 session 可能消失，ACP Wrapper 需處理 session 不存在的情況" +
-      "（自動透過 acp/createSession 重建）。",
-    "不同 Telegram chat 之間的 Kiro session 是獨立的，但同一 chat 內的所有 /kiro " +
-      "訊息共享同一個 session（by design，用於跨訊息記憶）。",
+    "OpenClaw's message:received hook cannot prevent messages from entering the main agent's context window. " +
+      "/kiro message content may still be visible to the main agent.",
+    "It is recommended to add a directive in SOUL.md instructing the main agent to ignore messages starting with /kiro, " +
+      "as a supplementary measure to hook-level isolation.",
+    "Sessions may disappear after kiro-cli restarts. The ACP Wrapper needs to handle the case where a session does not exist " +
+      "(automatically rebuild via acp/createSession).",
+    "Kiro sessions across different Telegram chats are isolated, but all /kiro messages within the same chat " +
+      "share a single session (by design, for cross-message memory).",
   ];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,16 +1,16 @@
 // ============================================================
-// 共用型別定義 — openclaw-kiro-telegram-acp skill
+// Shared type definitions — openclaw-kiro-telegram-acp skill
 // ============================================================
 
 // --- Config ---
 
 export interface SkillConfig {
-  kiroAgentName: string; // 預設: "kiro"
-  kiroTimeoutMs: number; // 預設: 120000
-  kiroWrapperCmd: string; // 預設: "kiro-acp-ask"
-  allowedChatIds: string[]; // 預設: []（空=不限制）
-  replyPrefix: string; // 預設: "🤖 Kiro"
-  debugMode: boolean; // 預設: false
+  kiroAgentName: string; // Default: "kiro"
+  kiroTimeoutMs: number; // Default: 120000
+  kiroWrapperCmd: string; // Default: "kiro-acp-ask"
+  allowedChatIds: string[]; // Default: [] (empty = no restrictions)
+  replyPrefix: string; // Default: "🤖 Kiro"
+  debugMode: boolean; // Default: false
 }
 
 // --- OpenClaw Event ---
@@ -131,9 +131,9 @@ export interface KiroSessionState {
 
 export interface ErrorTracker {
   chatId: string;
-  errors: number[]; // 錯誤發生的時間戳記陣列
-  windowMs: number; // 追蹤視窗（預設 300000 = 5 分鐘）
-  threshold: number; // 觸發額外提示的閾值（預設 3）
+  errors: number[]; // Array of error occurrence timestamps
+  windowMs: number; // Tracking window (default 300000 = 5 minutes)
+  threshold: number; // Threshold for triggering additional hints (default 3)
 }
 
 // --- ACP Wrapper ---


### PR DESCRIPTION
## What

Translate all Chinese comments and error messages to English in:
- `src/lib/config.ts`, `error-formatter.ts`, `acp-error-handler.ts`
- `src/lib/reply-suppressor.ts`, `session-isolator.ts`
- `src/types/index.ts`
- All corresponding test files in `src/lib/__tests__/`

## Why

Addresses issue #8 feedback — repo should use English for an open-source project.

~246 lines changed (comments and string translations only, no logic changes).