### PR TITLE
docs: translate hook handler and ACP wrapper to English

### DIFF
--- a/src/hook/__tests__/handler.test.ts
+++ b/src/hook/__tests__/handler.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { OpenClawEvent } from "../../types/index.js";
 
 // ============================================================
-// Mock 設定 — 必須在 import handler 之前完成
+// Mock setup — must be completed before importing handler
 // ============================================================
 
 // Mock child_process.execFile
@@ -11,7 +11,7 @@ vi.mock("node:child_process", () => ({
   execFile: (...args: unknown[]) => mockExecFile(...args),
 }));
 
-// Mock fs.readFileSync（getBotToken 使用）
+// Mock fs.readFileSync (used by getBotToken)
 vi.mock("node:fs", () => ({
   readFileSync: () =>
     JSON.stringify({
@@ -31,12 +31,12 @@ vi.mock("../../lib/config.js", () => ({
   }),
 }));
 
-// Mock global fetch（Telegram sendMessage）
+// Mock global fetch (Telegram sendMessage)
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 // ============================================================
-// Import handler 與內部函式
+// Import handler and internal functions
 // ============================================================
 
 import handler, {
@@ -46,10 +46,10 @@ import handler, {
 } from "../handler.js";
 
 // ============================================================
-// 測試輔助
+// Test helpers
 // ============================================================
 
-/** 建立 mock OpenClawEvent */
+/** Create a mock OpenClawEvent */
 function createEvent(overrides: Partial<OpenClawEvent> & {
   context?: Partial<OpenClawEvent["context"]>;
 } = {}): OpenClawEvent {
@@ -68,9 +68,9 @@ function createEvent(overrides: Partial<OpenClawEvent> & {
   };
 }
 
-/** 設定 mockExecFile 回傳成功結果 */
+/** Set mockExecFile to return a success result */
 function mockExecFileSuccess(text: string, stderr = "") {
-  // 模擬 `openclaw agent --json` 的 JSON 回覆格式
+  // Simulate `openclaw agent --json` JSON reply format
   const stdout = JSON.stringify({ result: { payloads: [{ text }] } });
   mockExecFile.mockImplementation(
     (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
@@ -79,7 +79,7 @@ function mockExecFileSuccess(text: string, stderr = "") {
   );
 }
 
-/** 設定 mockExecFile 回傳錯誤結果 */
+/** Set mockExecFile to return an error result */
 function mockExecFileError(exitCode: number, stderr: string, stdout = "") {
   mockExecFile.mockImplementation(
     (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
@@ -91,14 +91,14 @@ function mockExecFileError(exitCode: number, stderr: string, stdout = "") {
   );
 }
 
-/** 設定 fetch mock 回傳成功 */
+/** Set fetch mock to return success */
 function mockFetchSuccess() {
   mockFetch.mockResolvedValue({
     json: () => Promise.resolve({ ok: true }),
   });
 }
 
-/** 等待所有 microtask 完成 */
+/** Wait for all microtasks to complete */
 function flushPromises(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 50));
 }
@@ -126,9 +126,9 @@ describe("Hook Handler", () => {
     vi.restoreAllMocks();
   });
 
-  // ── /kiro 訊息觸發 ACP Wrapper 呼叫 ──────────────────────
-  describe("/kiro 訊息觸發 ACP Wrapper 呼叫", () => {
-    it("應使用 execFile 呼叫 ACP Wrapper 並傳入正確參數", async () => {
+  // ── /kiro message triggers ACP Wrapper call ───────────────
+  describe("/kiro message triggers ACP Wrapper call", () => {
+    it("should use execFile to call ACP Wrapper with correct arguments", async () => {
       const event = createEvent({
         context: { content: "/kiro what is TypeScript?" },
       });
@@ -147,7 +147,7 @@ describe("Hook Handler", () => {
       expect(args).toContain("--json");
     });
 
-    it("應將 ACP Wrapper 的 stdout 回覆傳送至 Telegram", async () => {
+    it("should send ACP Wrapper stdout reply to Telegram", async () => {
       mockExecFileSuccess("This is the Kiro reply");
 
       const event = createEvent();
@@ -165,7 +165,7 @@ describe("Hook Handler", () => {
       expect(body.text).toContain("This is the Kiro reply");
     });
 
-    it("空 prompt（僅 /kiro）應回傳 usage 訊息", async () => {
+    it("empty prompt (just /kiro) should return a usage message", async () => {
       const event = createEvent({
         context: { content: "/kiro" },
       });
@@ -173,16 +173,16 @@ describe("Hook Handler", () => {
       handler(event);
       await flushPromises();
 
-      // 不應呼叫 ACP Wrapper
+      // Should not call ACP Wrapper
       expect(mockExecFile).not.toHaveBeenCalled();
 
-      // 應傳送 usage 訊息
+      // Should send usage message
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const body = JSON.parse(mockFetch.mock.calls[0]![1].body);
       expect(body.text).toContain("Usage:");
     });
 
-    it("ACP Wrapper 錯誤時應透過 Error Formatter 處理並傳送友善訊息", async () => {
+    it("ACP Wrapper error should be processed through Error Formatter and send a friendly message", async () => {
       mockExecFileError(3, "timeout after 120000ms");
 
       const event = createEvent();
@@ -192,13 +192,13 @@ describe("Hook Handler", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const body = JSON.parse(mockFetch.mock.calls[0]![1].body);
       expect(body.text).toContain("🤖 Kiro");
-      expect(body.text).toContain("逾時");
+      expect(body.text).toContain("timed out");
     });
   });
 
-  // ── 非 /kiro 訊息不觸發處理 ────────────────────────────────
-  describe("非 /kiro 訊息不觸發處理", () => {
-    it("一般訊息不應觸發 ACP Wrapper", () => {
+  // ── Non-/kiro messages should not trigger processing ──────
+  describe("Non-/kiro messages should not trigger processing", () => {
+    it("regular messages should not trigger ACP Wrapper", () => {
       const event = createEvent({
         context: { content: "hello world" },
       });
@@ -210,7 +210,7 @@ describe("Hook Handler", () => {
       expect(result).toBeUndefined();
     });
 
-    it("非 telegram channel 不應觸發處理", () => {
+    it("non-telegram channel should not trigger processing", () => {
       const event = createEvent({
         context: { channelId: "discord", content: "/kiro hello" },
       });
@@ -221,7 +221,7 @@ describe("Hook Handler", () => {
       expect(result).toBeUndefined();
     });
 
-    it("非 message:received 事件不應觸發處理", () => {
+    it("non-message:received events should not trigger processing", () => {
       const event = createEvent({ type: "connection", action: "opened" });
 
       const result = handler(event);
@@ -230,7 +230,7 @@ describe("Hook Handler", () => {
       expect(result).toBeUndefined();
     });
 
-    it("非 agent:main:telegram:direct: session key 不應觸發處理", () => {
+    it("non agent:main:telegram:direct: session key should not trigger processing", () => {
       const event = createEvent({
         sessionKey: "agent:secondary:telegram:group:999",
         context: { content: "/kiro hello" },
@@ -243,10 +243,10 @@ describe("Hook Handler", () => {
     });
   });
 
-  // ── ALLOWED_CHAT_IDS 過濾邏輯 ──────────────────────────────
-  describe("ALLOWED_CHAT_IDS 過濾邏輯", () => {
-    it("allowedChatIds 為空時應允許所有 chatId", async () => {
-      // 預設 config 的 allowedChatIds 為 []
+  // ── ALLOWED_CHAT_IDS filtering logic ──────────────────────
+  describe("ALLOWED_CHAT_IDS filtering logic", () => {
+    it("empty allowedChatIds should allow all chatIds", async () => {
+      // Default config has allowedChatIds as []
       const event = createEvent({
         context: { conversationId: "telegram:99999" },
       });
@@ -257,8 +257,8 @@ describe("Hook Handler", () => {
       expect(mockExecFile).toHaveBeenCalledTimes(1);
     });
 
-    it("chatId 不在 allowedChatIds 中時不應觸發處理", async () => {
-      // 動態修改 config（透過 import 的 config 物件）
+    it("chatId not in allowedChatIds should not trigger processing", async () => {
+      // Dynamically modify config (via the imported config object)
       const { config: handlerConfig } = await import("../handler.js");
       const originalIds = [...handlerConfig.allowedChatIds];
       handlerConfig.allowedChatIds = ["allowed-1", "allowed-2"];
@@ -277,7 +277,7 @@ describe("Hook Handler", () => {
       }
     });
 
-    it("chatId 在 allowedChatIds 中時應正常處理", async () => {
+    it("chatId in allowedChatIds should be processed normally", async () => {
       const { config: handlerConfig } = await import("../handler.js");
       const originalIds = [...handlerConfig.allowedChatIds];
       handlerConfig.allowedChatIds = ["12345", "67890"];
@@ -297,14 +297,14 @@ describe("Hook Handler", () => {
     });
   });
 
-  // ── message:sending 取消邏輯 ────────────────────────────────
-  describe("message:sending 取消邏輯", () => {
-    it("有 pending /kiro session 時應回傳 { cancel: true }", () => {
-      // 先觸發 message:received 標記 session
+  // ── message:sending cancel logic ──────────────────────────
+  describe("message:sending cancel logic", () => {
+    it("should return { cancel: true } when there is a pending /kiro session", () => {
+      // First trigger message:received to mark the session
       const receivedEvent = createEvent();
       handler(receivedEvent);
 
-      // 然後觸發 message:sending
+      // Then trigger message:sending
       const sendingEvent = createEvent({
         action: "sending",
       });
@@ -313,7 +313,7 @@ describe("Hook Handler", () => {
       expect(result).toEqual({ cancel: true });
     });
 
-    it("無 pending session 時不應取消", () => {
+    it("should not cancel when there is no pending session", () => {
       const sendingEvent = createEvent({
         action: "sending",
         sessionKey: "agent:main:telegram:direct:no-pending",
@@ -323,33 +323,33 @@ describe("Hook Handler", () => {
       expect(result).toBeUndefined();
     });
 
-    it("取消後再次 sending 不應重複取消（一次性消費）", () => {
-      // 標記 session
+    it("should not cancel again after consumption (one-time use)", () => {
+      // Mark session
       const receivedEvent = createEvent();
       handler(receivedEvent);
 
       const sendingEvent = createEvent({ action: "sending" });
 
-      // 第一次取消
+      // First cancel
       const result1 = handler(sendingEvent);
       expect(result1).toEqual({ cancel: true });
 
-      // 第二次不應取消
+      // Second should not cancel
       const result2 = handler(sendingEvent);
       expect(result2).toBeUndefined();
     });
   });
 
-  // ── extractChatId ──────────────────────────────────────────
+  // ── extractChatId ─────────────────────────────────────────
   describe("extractChatId()", () => {
-    it("應移除 telegram: 前綴", () => {
+    it("should remove the telegram: prefix", () => {
       const event = createEvent({
         context: { conversationId: "telegram:12345" },
       });
       expect(extractChatId(event)).toBe("12345");
     });
 
-    it("無前綴時應回傳原始值", () => {
+    it("should return the raw value when there is no prefix", () => {
       const event = createEvent({
         context: { conversationId: "67890" },
       });
@@ -357,34 +357,34 @@ describe("Hook Handler", () => {
     });
   });
 
-  // ── Provider 錯誤頻率追蹤 ──────────────────────────────────
-  describe("Provider 錯誤頻率追蹤", () => {
-    it("未達閾值時應回傳 false", () => {
+  // ── Provider error frequency tracking ─────────────────────
+  describe("Provider error frequency tracking", () => {
+    it("should return false when threshold is not reached", () => {
       expect(trackProviderError("user-1")).toBe(false);
       expect(trackProviderError("user-1")).toBe(false);
     });
 
-    it("達到 3 次閾值時應回傳 true", () => {
+    it("should return true when the threshold of 3 is reached", () => {
       trackProviderError("user-2");
       trackProviderError("user-2");
       expect(trackProviderError("user-2")).toBe(true);
     });
 
-    it("不同 chatId 應獨立追蹤", () => {
+    it("different chatIds should be tracked independently", () => {
       trackProviderError("user-a");
       trackProviderError("user-a");
       trackProviderError("user-b");
 
-      expect(trackProviderError("user-a")).toBe(true); // 第 3 次
-      expect(trackProviderError("user-b")).toBe(false); // 僅第 2 次
+      expect(trackProviderError("user-a")).toBe(true); // 3rd time
+      expect(trackProviderError("user-b")).toBe(false); // only 2nd time
     });
 
-    it("clearProviderErrors 應清除指定 chatId 的記錄", () => {
+    it("clearProviderErrors should clear records for the specified chatId", () => {
       trackProviderError("user-c");
       trackProviderError("user-c");
       clearProviderErrors("user-c");
 
-      expect(trackProviderError("user-c")).toBe(false); // 重新計數
+      expect(trackProviderError("user-c")).toBe(false); // recount
     });
   });
 });

--- a/src/hook/handler.ts
+++ b/src/hook/handler.ts
@@ -1,23 +1,23 @@
 // ============================================================
-// Hook Handler — OpenClaw 事件處理器，整合所有模組進行訊息路由
-// 對應需求: 6.1, 6.2, 6.3, 12.1–12.5, 13.1–13.3, 15.4, 15.5
+// Hook Handler — OpenClaw event handler, integrating all modules for message routing
+// Requirements: 6.1, 6.2, 6.3, 12.1–12.5, 13.1–13.3, 15.4, 15.5
 // ============================================================
 //
-// 為何使用 ACP Wrapper（kiro-acp-ask）而非直接呼叫 `openclaw agent --message` CLI？
+// Why use an ACP Wrapper (kiro-acp-ask) instead of calling `openclaw agent --message` CLI directly?
 //
-// 根據 docs/wrapper-contract.md 的說明：
-// OpenClaw 2026.4.2 的 `openclaw acp` 是一個 stdio ACP bridge server，
-// 而非 HTTP endpoint 或 one-shot CLI 指令。Telegram hook 需要 request/response
-// 行為，因此透過一個薄 wrapper（kiro-acp-ask）作為橋接是最乾淨的方式。
+// Per docs/wrapper-contract.md:
+// OpenClaw 2026.4.2's `openclaw acp` is a stdio ACP bridge server,
+// not an HTTP endpoint or a one-shot CLI command. The Telegram hook needs request/response
+// behavior, so using a thin wrapper (kiro-acp-ask) as a bridge is the cleanest approach.
 //
-// Wrapper 的職責：
-// 1. 接受 agent 名稱與 prompt 作為命令列參數
-// 2. 透過 stdio JSON-RPC 與 `openclaw acp` bridge 通訊
-// 3. 僅將最終回覆文字輸出至 stdout
-// 4. 失敗時回傳非零 exit code
-// 5. 將 debug/error 訊息輸出至 stderr
+// Wrapper responsibilities:
+// 1. Accept agent name and prompt as command-line arguments
+// 2. Communicate with the `openclaw acp` bridge via stdio JSON-RPC
+// 3. Output only the final reply text to stdout
+// 4. Return a non-zero exit code on failure
+// 5. Output debug/error messages to stderr
 //
-// 使用 `execFile`（而非 `execSync`）避免阻塞 gateway event loop。
+// Uses `execFile` (not `execSync`) to avoid blocking the gateway event loop.
 // ============================================================
 
 import { readFileSync } from "node:fs";
@@ -30,7 +30,7 @@ import { handleAcpError } from "../lib/acp-error-handler.js";
 import type { OpenClawEvent, SkillConfig } from "../types/index.js";
 
 // ============================================================
-// 設定載入（模組層級，僅載入一次）
+// Config loading (module level, loaded once)
 // ============================================================
 
 let config: SkillConfig;
@@ -40,7 +40,7 @@ try {
   process.stderr.write(
     `[hook] Failed to load config: ${(err as Error).message}\n`,
   );
-  // 使用預設值作為 fallback，避免 hook 完全無法載入
+  // Use default values as fallback to prevent hook from failing to load entirely
   config = {
     kiroAgentName: "kiro",
     kiroTimeoutMs: 120_000,
@@ -52,18 +52,18 @@ try {
 }
 
 // ============================================================
-// Provider 錯誤頻率追蹤（需求 15.5）
-// 同一使用者 5 分鐘內連續 3 次 provider 錯誤時額外提示
+// Provider error frequency tracking (Requirement 15.5)
+// Show additional hint when the same user hits 3 consecutive provider errors within 5 minutes
 // ============================================================
 
-const PROVIDER_ERROR_WINDOW_MS = 5 * 60 * 1000; // 5 分鐘
+const PROVIDER_ERROR_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
 const PROVIDER_ERROR_THRESHOLD = 3;
 
-/** chatId → 錯誤時間戳記陣列 */
+/** chatId → array of error timestamps */
 const providerErrorTracker = new Map<string, number[]>();
 
 /**
- * 記錄一次 provider 錯誤，並回傳是否已達到頻率閾值。
+ * Record a provider error and return whether the frequency threshold has been reached.
  */
 export function trackProviderError(chatId: string): boolean {
   const now = Date.now();
@@ -76,7 +76,7 @@ export function trackProviderError(chatId: string): boolean {
 
   timestamps.push(now);
 
-  // 清除超出視窗的舊記錄
+  // Remove old records outside the window
   const cutoff = now - PROVIDER_ERROR_WINDOW_MS;
   const filtered = timestamps.filter((t) => t > cutoff);
   providerErrorTracker.set(chatId, filtered);
@@ -85,8 +85,8 @@ export function trackProviderError(chatId: string): boolean {
 }
 
 /**
- * 清除指定 chatId 的 provider 錯誤追蹤記錄。
- * 主要供測試使用。
+ * Clear provider error tracking records for a given chatId.
+ * Primarily used for testing.
  */
 export function clearProviderErrors(chatId?: string): void {
   if (chatId) {
@@ -97,12 +97,12 @@ export function clearProviderErrors(chatId?: string): void {
 }
 
 // ============================================================
-// Telegram 訊息傳送
+// Telegram message sending
 // ============================================================
 
 /**
- * 從 ~/.openclaw/openclaw.json 讀取 bot token。
- * 使用 readFileSync 確保同步取得（避免 race condition）。
+ * Read the bot token from ~/.openclaw/openclaw.json.
+ * Uses readFileSync to ensure synchronous retrieval (avoid race conditions).
  */
 function getBotToken(): string {
   const cfgPath = `${process.env.HOME}/.openclaw/openclaw.json`;
@@ -112,7 +112,7 @@ function getBotToken(): string {
 }
 
 /**
- * 透過 Telegram Bot API 傳送訊息。
+ * Send a message via the Telegram Bot API.
  */
 async function sendTelegram(chatId: string, text: string): Promise<void> {
   const token = getBotToken();
@@ -131,24 +131,25 @@ async function sendTelegram(chatId: string, text: string): Promise<void> {
 }
 
 // ============================================================
-// Agent 呼叫
+// Agent invocation
 // ============================================================
 
 /**
- * 透過 `openclaw agent --message --json` 呼叫 agent，非阻塞。
+ * Invoke the agent via `openclaw agent --message --json`, non-blocking.
  *
- * 此方式為 one-shot CLI 指令，會等待 agent 回覆並輸出至 stdout。
- * 使用 --session-id 實現跨訊息記憶（同一 chatId 使用同一 session）。
- * 使用 --json 取得結構化回覆，方便解析。
+ * This is a one-shot CLI command that waits for the agent reply and outputs to stdout.
+ * Uses --session-id for cross-message memory (same chatId uses the same session).
+ * Uses --json for structured replies, making parsing easier.
  *
- * 參見 docs/wrapper-contract.md：
- * - stdout → JSON 格式回覆（含 result.payloads[0].text）
- * - stderr → 診斷訊息
- * - exit code 0 → 成功, 非零 → 錯誤
+ * See docs/wrapper-contract.md:
+ * - stdout → JSON-formatted reply (containing result.payloads[0].text)
+ * - stderr → diagnostic messages
+ * - exit code 0 → success, non-zero → error
  *
- * 注意：設計文件原本規劃使用 `openclaw acp` stdio bridge + kiro-acp-ask wrapper，
- * 但經實測發現 ACP bridge 在 hook 場景下會將回覆路由至 Telegram 而非回傳給 client。
- * 因此暫時改用 `openclaw agent --message --json` 方式，待 ACP bridge 問題釐清後再切換。
+ * Note: The design doc originally planned to use `openclaw acp` stdio bridge + kiro-acp-ask wrapper,
+ * but testing revealed the ACP bridge routes replies to Telegram instead of returning them to the client
+ * in hook scenarios. Therefore, `openclaw agent --message --json` is used temporarily until the ACP
+ * bridge issue is resolved.
  */
 function callAgent(
   prompt: string,
@@ -195,8 +196,8 @@ function callAgent(
 }
 
 /**
- * 從 `openclaw agent --json` 的 stdout 解析回覆文字。
- * JSON 格式：{ result: { payloads: [{ text: "..." }] } }
+ * Parse the reply text from `openclaw agent --json` stdout.
+ * JSON format: { result: { payloads: [{ text: "..." }] } }
  */
 function parseAgentResponse(stdout: string): string {
   try {
@@ -206,18 +207,18 @@ function parseAgentResponse(stdout: string): string {
       return text;
     }
   } catch {
-    // 非 JSON 格式，直接回傳原始文字
+    // Not JSON format, return raw text
   }
   return stdout.trim();
 }
 
 // ============================================================
-// 輔助函式
+// Helper functions
 // ============================================================
 
 /**
- * 從 OpenClaw event context 提取 Telegram chat ID。
- * OpenClaw 使用 `conversationId` 並帶有 `telegram:` 前綴。
+ * Extract the Telegram chat ID from the OpenClaw event context.
+ * OpenClaw uses `conversationId` with a `telegram:` prefix.
  */
 function extractChatId(event: OpenClawEvent): string {
   const raw = String(event?.context?.conversationId ?? event?.context?.from ?? "");
@@ -225,21 +226,21 @@ function extractChatId(event: OpenClawEvent): string {
 }
 
 // ============================================================
-// 核心處理邏輯
+// Core processing logic
 // ============================================================
 
 /**
- * 處理 /kiro 指令：呼叫 ACP Wrapper 並傳送回覆至 Telegram。
+ * Handle the /kiro command: invoke the ACP Wrapper and send the reply to Telegram.
  */
 async function handleKiroQuery(chatId: string, query: string, sessionId: string): Promise<void> {
   try {
     const result = await callAgent(query, sessionId);
 
     if (result.exitCode !== 0) {
-      // 錯誤路徑：透過 Error Formatter 處理
+      // Error path: process through Error Formatter
       const combined = [result.stdout, result.stderr].filter(Boolean).join("\n");
 
-      // 先嘗試 ACP Error Handler（辨識權限類錯誤）
+      // First try ACP Error Handler (identify permission-related errors)
       const acpResult = handleAcpError(combined);
       if (acpResult.isAcpError) {
         const message = `${config.replyPrefix}\n\n${acpResult.userMessage}\n\n${acpResult.fixSuggestions.join("\n")}`;
@@ -247,10 +248,10 @@ async function handleKiroQuery(chatId: string, query: string, sessionId: string)
         return;
       }
 
-      // 使用通用 Error Formatter
+      // Use the general Error Formatter
       const formatted = formatError(combined, result.exitCode);
 
-      // 記錄完整錯誤至 stderr（需求 15.4）
+      // Log full error to stderr (Requirement 15.4)
       const timestamp = new Date().toISOString();
       const promptSummary = query.slice(0, 50);
       process.stderr.write(
@@ -259,11 +260,11 @@ async function handleKiroQuery(chatId: string, query: string, sessionId: string)
 
       let userMessage = `${config.replyPrefix}\n\n${formatted.userMessage}`;
 
-      // Provider 錯誤頻率追蹤（需求 15.5）
+      // Provider error frequency tracking (Requirement 15.5)
       if (formatted.errorType === "provider") {
         const exceeded = trackProviderError(chatId);
         if (exceeded) {
-          userMessage += "\n\n如持續發生此問題，請聯繫管理員檢查 AI provider 狀態。";
+          userMessage += "\n\nIf this issue persists, please contact the administrator to check the AI provider status.";
         }
       }
 
@@ -271,14 +272,14 @@ async function handleKiroQuery(chatId: string, query: string, sessionId: string)
       return;
     }
 
-    // 成功路徑：解析 JSON 回覆並檢查 provider 錯誤（需求 15.3）
+    // Success path: parse JSON reply and check for provider errors (Requirement 15.3)
     const replyText = parseAgentResponse(result.stdout);
     if (!replyText) {
-      await sendTelegram(chatId, `${config.replyPrefix}\n\n⚠️ 收到空白回覆，請稍後再試。`);
+      await sendTelegram(chatId, `${config.replyPrefix}\n\n⚠️ Received an empty reply. Please try again later.`);
       return;
     }
 
-    // 檢查回覆是否包含 provider 錯誤
+    // Check if the reply contains a provider error
     const formatted = formatError(replyText, 0);
     if (formatted.errorType === "provider") {
       const timestamp = new Date().toISOString();
@@ -291,50 +292,50 @@ async function handleKiroQuery(chatId: string, query: string, sessionId: string)
 
       const exceeded = trackProviderError(chatId);
       if (exceeded) {
-        userMessage += "\n\n如持續發生此問題，請聯繫管理員檢查 AI provider 狀態。";
+        userMessage += "\n\nIf this issue persists, please contact the administrator to check the AI provider status.";
       }
 
       await sendTelegram(chatId, userMessage);
       return;
     }
 
-    // 正常回覆
+    // Normal reply
     await sendTelegram(chatId, `${config.replyPrefix}\n\n${replyText}`);
   } catch (err: unknown) {
-    // 最後防線：任何未預期的錯誤
+    // Last resort: any unexpected error
     process.stderr.write(
       `[hook] Unexpected error handling /kiro query: ${(err as Error).message}\n`,
     );
     try {
       await sendTelegram(
         chatId,
-        `${config.replyPrefix}\n\n⚠️ Kiro 暫時無法處理您的請求，請稍後再試。`,
+        `${config.replyPrefix}\n\n⚠️ Kiro is temporarily unable to process your request. Please try again later.`,
       );
     } catch {
-      // 連 Telegram 都無法傳送，只能記錄至 stderr
+      // Cannot even send to Telegram, can only log to stderr
       process.stderr.write(`[hook] Failed to send error message to Telegram\n`);
     }
   }
 }
 
 // ============================================================
-// Hook Handler（default export，符合 OpenClaw hook 慣例）
+// Hook Handler (default export, follows OpenClaw hook convention)
 // ============================================================
 
 /**
- * OpenClaw Hook Handler — 處理 message:received 與 message:sending 事件。
+ * OpenClaw Hook Handler — handles message:received and message:sending events.
  *
- * message:received（void hook）：
- *   驗證 channel、chatId、/kiro prefix → markSession()（同步）
- *   → getKiroSessionId() → execFile 呼叫 ACP Wrapper → Error Formatter → Telegram
+ * message:received (void hook):
+ *   Validate channel, chatId, /kiro prefix → markSession() (sync)
+ *   → getKiroSessionId() → execFile to invoke ACP Wrapper → Error Formatter → Telegram
  *
- * message:sending（可回傳 { cancel: true }）：
- *   shouldCancel() 檢查是否需取消主 agent 回覆
+ * message:sending (can return { cancel: true }):
+ *   shouldCancel() checks whether to cancel the main agent reply
  */
 const handler = (event: OpenClawEvent): void | { cancel: true } => {
   // ── message:sending ─────────────────────────────────────────
-  // 取消主 OpenClaw agent 回覆（當 /kiro 指令正在處理時）。
-  // 只有 message:sending 支援 { cancel: true } 回傳值。
+  // Cancel the main OpenClaw agent reply (when a /kiro command is being processed).
+  // Only message:sending supports the { cancel: true } return value.
   if (event?.type === "message" && event?.action === "sending") {
     const sessionKey = String(event?.sessionKey ?? "");
     if (shouldCancel(sessionKey)) {
@@ -351,39 +352,39 @@ const handler = (event: OpenClawEvent): void | { cancel: true } => {
   const chatId = extractChatId(event);
   const sessionKey = String(event?.sessionKey ?? "");
 
-  // 僅處理 Telegram direct message session（需求 13.1, 13.2）
+  // Only handle Telegram direct message sessions (Requirements 13.1, 13.2)
   if (!sessionKey.startsWith("agent:main:telegram:direct:")) return;
 
-  // 檢查 /kiro 前綴
+  // Check /kiro prefix
   if (!content || !content.startsWith("/kiro")) return;
 
-  // ALLOWED_CHAT_IDS 過濾（空陣列 = 不限制）
+  // ALLOWED_CHAT_IDS filter (empty array = no restrictions)
   if (config.allowedChatIds.length > 0 && !config.allowedChatIds.includes(chatId)) {
     return;
   }
 
-  // 同步標記 session（需求 12.3）
-  // 必須在任何 async 操作之前完成，確保 message:sending 能偵測到標記
+  // Synchronously mark session (Requirement 12.3)
+  // Must complete before any async operations to ensure message:sending hook can detect the mark
   markSession(sessionKey);
 
-  // 取得固定的 Kiro session ID（需求 13.5）
-  // 同一 chatId 永遠對應同一 session，實現跨訊息記憶
+  // Get the fixed Kiro session ID (Requirement 13.5)
+  // Same chatId always maps to the same session, enabling cross-message memory
   const kiroSessionId = getKiroSessionId(chatId);
 
-  // 解析 prompt
+  // Parse prompt
   const query = content.replace(/^\/kiro\s*/, "").trim();
   if (!query) {
     void sendTelegram(chatId, `${config.replyPrefix}\n\nUsage: /kiro <your question>`);
     return;
   }
 
-  // 非同步呼叫 ACP Wrapper（不阻塞 gateway event loop）
+  // Async invoke ACP Wrapper (non-blocking for gateway event loop)
   void handleKiroQuery(chatId, query, kiroSessionId);
 };
 
 export default handler;
 
-// 匯出內部函式供測試使用
+// Export internal functions for testing
 export {
   extractChatId,
   handleKiroQuery,

--- a/src/wrapper/__tests__/kiro-acp-ask.test.ts
+++ b/src/wrapper/__tests__/kiro-acp-ask.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../kiro-acp-ask.js";
 
 // ============================================================
-// JSON-RPC 序列化 / 反序列化
+// JSON-RPC serialization / deserialization
 // ============================================================
 
 describe("JSON-RPC helpers", () => {
@@ -23,7 +23,7 @@ describe("JSON-RPC helpers", () => {
   });
 
   describe("buildJsonRpcRequest()", () => {
-    it("應建立符合 JSON-RPC 2.0 格式的 request", () => {
+    it("should build a request conforming to JSON-RPC 2.0 format", () => {
       const req = buildJsonRpcRequest("initialize", { foo: "bar" });
 
       expect(req.jsonrpc).toBe("2.0");
@@ -32,7 +32,7 @@ describe("JSON-RPC helpers", () => {
       expect(req.params).toEqual({ foo: "bar" });
     });
 
-    it("每次呼叫應遞增 id", () => {
+    it("should increment id on each call", () => {
       const r1 = buildJsonRpcRequest("a");
       const r2 = buildJsonRpcRequest("b");
       const r3 = buildJsonRpcRequest("c");
@@ -42,7 +42,7 @@ describe("JSON-RPC helpers", () => {
       expect(r3.id).toBe(3);
     });
 
-    it("無 params 時不應包含 params 欄位", () => {
+    it("should not include params field when no params are provided", () => {
       const req = buildJsonRpcRequest("shutdown");
 
       expect(req).not.toHaveProperty("params");
@@ -50,7 +50,7 @@ describe("JSON-RPC helpers", () => {
   });
 
   describe("serializeRequest()", () => {
-    it("應序列化為 JSON 字串並以換行結尾", () => {
+    it("should serialize to a JSON string ending with a newline", () => {
       const req = buildJsonRpcRequest("initialize");
       const serialized = serializeRequest(req);
 
@@ -62,7 +62,7 @@ describe("JSON-RPC helpers", () => {
   });
 
   describe("parseResponses()", () => {
-    it("應從完整的 JSON 行中解析出 response", () => {
+    it("should parse responses from complete JSON lines", () => {
       const resp: JsonRpcResponse = {
         jsonrpc: "2.0",
         id: 1,
@@ -78,7 +78,7 @@ describe("JSON-RPC helpers", () => {
       expect(remaining).toBe("");
     });
 
-    it("應處理多個 response 在同一 buffer 中", () => {
+    it("should handle multiple responses in the same buffer", () => {
       const r1: JsonRpcResponse = { jsonrpc: "2.0", id: 1, result: {} };
       const r2: JsonRpcResponse = { jsonrpc: "2.0", id: 2, result: {} };
       const buffer = JSON.stringify(r1) + "\n" + JSON.stringify(r2) + "\n";
@@ -91,7 +91,7 @@ describe("JSON-RPC helpers", () => {
       expect(remaining).toBe("");
     });
 
-    it("應保留不完整的行作為 remaining buffer", () => {
+    it("should preserve incomplete lines as remaining buffer", () => {
       const complete: JsonRpcResponse = { jsonrpc: "2.0", id: 1, result: {} };
       const buffer = JSON.stringify(complete) + "\n" + '{"jsonrpc":"2.0","id":2';
 
@@ -101,7 +101,7 @@ describe("JSON-RPC helpers", () => {
       expect(remaining).toBe('{"jsonrpc":"2.0","id":2');
     });
 
-    it("應忽略空行", () => {
+    it("should ignore empty lines", () => {
       const resp: JsonRpcResponse = { jsonrpc: "2.0", id: 1, result: {} };
       const buffer = "\n\n" + JSON.stringify(resp) + "\n\n";
 
@@ -110,7 +110,7 @@ describe("JSON-RPC helpers", () => {
       expect(responses).toHaveLength(1);
     });
 
-    it("應忽略非 JSON-RPC 格式的行", () => {
+    it("should ignore non-JSON-RPC format lines", () => {
       const buffer = "some random log output\n" +
         JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }) + "\n" +
         "another log line\n";
@@ -121,7 +121,7 @@ describe("JSON-RPC helpers", () => {
       expect(responses[0]!.id).toBe(1);
     });
 
-    it("空 buffer 應回傳空陣列", () => {
+    it("empty buffer should return an empty array", () => {
       const [responses, remaining] = parseResponses("");
 
       expect(responses).toHaveLength(0);
@@ -131,11 +131,11 @@ describe("JSON-RPC helpers", () => {
 });
 
 // ============================================================
-// Session not found 偵測
+// Session not found detection
 // ============================================================
 
 describe("isSessionNotFoundError()", () => {
-  it("error.message 包含 'session not found' 時應回傳 true", () => {
+  it("should return true when error.message contains 'session not found'", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -144,7 +144,7 @@ describe("isSessionNotFoundError()", () => {
     expect(isSessionNotFoundError(resp)).toBe(true);
   });
 
-  it("error.message 包含 'session does not exist' 時應回傳 true", () => {
+  it("should return true when error.message contains 'session does not exist'", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -153,7 +153,7 @@ describe("isSessionNotFoundError()", () => {
     expect(isSessionNotFoundError(resp)).toBe(true);
   });
 
-  it("error.message 包含 'no such session' 時應回傳 true", () => {
+  it("should return true when error.message contains 'no such session'", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -162,7 +162,7 @@ describe("isSessionNotFoundError()", () => {
     expect(isSessionNotFoundError(resp)).toBe(true);
   });
 
-  it("error.data 包含 'session not found' 時應回傳 true", () => {
+  it("should return true when error.data contains 'session not found'", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -171,7 +171,7 @@ describe("isSessionNotFoundError()", () => {
     expect(isSessionNotFoundError(resp)).toBe(true);
   });
 
-  it("error.message 包含 'invalid session' 時應回傳 true", () => {
+  it("should return true when error.message contains 'invalid session'", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -180,7 +180,7 @@ describe("isSessionNotFoundError()", () => {
     expect(isSessionNotFoundError(resp)).toBe(true);
   });
 
-  it("無 error 時應回傳 false", () => {
+  it("should return false when there is no error", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -189,7 +189,7 @@ describe("isSessionNotFoundError()", () => {
     expect(isSessionNotFoundError(resp)).toBe(false);
   });
 
-  it("不相關的 error 應回傳 false", () => {
+  it("should return false for unrelated errors", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -200,7 +200,7 @@ describe("isSessionNotFoundError()", () => {
 });
 
 // ============================================================
-// Session 建立與 fallback 邏輯
+// Session setup and fallback logic
 // ============================================================
 
 describe("Session setup", () => {
@@ -209,7 +209,7 @@ describe("Session setup", () => {
   });
 
   describe("buildSessionRequests()", () => {
-    it("有 sessionId 時應建立 bindSession request", () => {
+    it("should build a bindSession request when sessionId is provided", () => {
       const [req, method] = buildSessionRequests("kiro", "session-123");
 
       expect(method).toBe("acp/bindSession");
@@ -220,7 +220,7 @@ describe("Session setup", () => {
       });
     });
 
-    it("無 sessionId 時應建立 createSession request", () => {
+    it("should build a createSession request when no sessionId is provided", () => {
       const [req, method] = buildSessionRequests("kiro");
 
       expect(method).toBe("acp/createSession");
@@ -228,7 +228,7 @@ describe("Session setup", () => {
       expect(req.params).toEqual({ agentName: "kiro" });
     });
 
-    it("sessionId 為 undefined 時應建立 createSession request", () => {
+    it("should build a createSession request when sessionId is undefined", () => {
       const [req, method] = buildSessionRequests("kiro", undefined);
 
       expect(method).toBe("acp/createSession");
@@ -237,7 +237,7 @@ describe("Session setup", () => {
   });
 
   describe("buildFallbackCreateRequest()", () => {
-    it("應建立 createSession request", () => {
+    it("should build a createSession request", () => {
       const req = buildFallbackCreateRequest("kiro");
 
       expect(req.method).toBe("acp/createSession");
@@ -246,7 +246,7 @@ describe("Session setup", () => {
   });
 
   describe("handleSessionResponse()", () => {
-    it("成功的 createSession 應回傳 ok + sessionId", () => {
+    it("successful createSession should return ok + sessionId", () => {
       const resp: JsonRpcResponse = {
         jsonrpc: "2.0",
         id: 1,
@@ -261,7 +261,7 @@ describe("Session setup", () => {
       });
     });
 
-    it("成功的 bindSession 應回傳 ok + sessionId", () => {
+    it("successful bindSession should return ok + sessionId", () => {
       const resp: JsonRpcResponse = {
         jsonrpc: "2.0",
         id: 1,
@@ -276,7 +276,7 @@ describe("Session setup", () => {
       });
     });
 
-    it("應支援 session_id（snake_case）欄位名稱", () => {
+    it("should support session_id (snake_case) field name", () => {
       const resp: JsonRpcResponse = {
         jsonrpc: "2.0",
         id: 1,
@@ -291,7 +291,7 @@ describe("Session setup", () => {
       });
     });
 
-    it("bindSession 遇到 session not found 應回傳 fallback", () => {
+    it("bindSession encountering session not found should return fallback", () => {
       const resp: JsonRpcResponse = {
         jsonrpc: "2.0",
         id: 1,
@@ -303,7 +303,7 @@ describe("Session setup", () => {
       expect(result).toEqual({ action: "fallback" });
     });
 
-    it("createSession 遇到 session not found 應回傳 error（不 fallback）", () => {
+    it("createSession encountering session not found should return error (no fallback)", () => {
       const resp: JsonRpcResponse = {
         jsonrpc: "2.0",
         id: 1,
@@ -315,7 +315,7 @@ describe("Session setup", () => {
       expect(result.action).toBe("error");
     });
 
-    it("bindSession 遇到非 session-not-found 錯誤應回傳 error", () => {
+    it("bindSession encountering non-session-not-found error should return error", () => {
       const resp: JsonRpcResponse = {
         jsonrpc: "2.0",
         id: 1,
@@ -330,7 +330,7 @@ describe("Session setup", () => {
       }
     });
 
-    it("response 缺少 sessionId 應回傳 error", () => {
+    it("response missing sessionId should return error", () => {
       const resp: JsonRpcResponse = {
         jsonrpc: "2.0",
         id: 1,
@@ -352,7 +352,7 @@ describe("Session setup", () => {
 // ============================================================
 
 describe("extractReplyText()", () => {
-  it("應從 result.text 提取回覆文字", () => {
+  it("should extract reply text from result.text", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -362,7 +362,7 @@ describe("extractReplyText()", () => {
     expect(extractReplyText(resp)).toBe("Hello from Kiro!");
   });
 
-  it("應從 result.content 提取回覆文字", () => {
+  it("should extract reply text from result.content", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -372,7 +372,7 @@ describe("extractReplyText()", () => {
     expect(extractReplyText(resp)).toBe("Content field reply");
   });
 
-  it("應從 result.message 提取回覆文字", () => {
+  it("should extract reply text from result.message", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -382,7 +382,7 @@ describe("extractReplyText()", () => {
     expect(extractReplyText(resp)).toBe("Message field reply");
   });
 
-  it("result.text 優先於 result.content", () => {
+  it("result.text should take priority over result.content", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -392,7 +392,7 @@ describe("extractReplyText()", () => {
     expect(extractReplyText(resp)).toBe("primary");
   });
 
-  it("response 有 error 時應拋出錯誤", () => {
+  it("should throw an error when response has an error", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -402,7 +402,7 @@ describe("extractReplyText()", () => {
     expect(() => extractReplyText(resp)).toThrow("Something went wrong");
   });
 
-  it("result 為空物件時應回傳空字串", () => {
+  it("should return an empty string when result is an empty object", () => {
     const resp: JsonRpcResponse = {
       jsonrpc: "2.0",
       id: 1,
@@ -414,11 +414,11 @@ describe("extractReplyText()", () => {
 });
 
 // ============================================================
-// CLI 參數解析
+// CLI argument parsing
 // ============================================================
 
 describe("parseCLIArgs()", () => {
-  it("應正確解析 agent 與 prompt", () => {
+  it("should correctly parse agent and prompt", () => {
     const result = parseCLIArgs(["node", "script.js", "kiro", "hello world"]);
 
     expect(result).toEqual({
@@ -427,7 +427,7 @@ describe("parseCLIArgs()", () => {
     });
   });
 
-  it("應將多個 prompt 參數合併為一個字串", () => {
+  it("should merge multiple prompt arguments into a single string", () => {
     const result = parseCLIArgs([
       "node", "script.js", "kiro", "hello", "beautiful", "world",
     ]);
@@ -438,7 +438,7 @@ describe("parseCLIArgs()", () => {
     });
   });
 
-  it("應解析 --session-id 選項", () => {
+  it("should parse the --session-id option", () => {
     const result = parseCLIArgs([
       "node", "script.js", "kiro", "hello", "--session-id", "sess-123",
     ]);
@@ -450,7 +450,7 @@ describe("parseCLIArgs()", () => {
     });
   });
 
-  it("--session-id 在 prompt 之前也應正確解析", () => {
+  it("--session-id before prompt should also be parsed correctly", () => {
     const result = parseCLIArgs([
       "node", "script.js", "--session-id", "sess-456", "kiro", "hello",
     ]);
@@ -462,19 +462,19 @@ describe("parseCLIArgs()", () => {
     });
   });
 
-  it("參數不足時應回傳 null", () => {
+  it("should return null when arguments are insufficient", () => {
     expect(parseCLIArgs(["node", "script.js"])).toBeNull();
     expect(parseCLIArgs(["node", "script.js", "kiro"])).toBeNull();
   });
 
-  it("僅有 --session-id 無 agent/prompt 時應回傳 null", () => {
+  it("should return null when only --session-id is provided without agent/prompt", () => {
     expect(
       parseCLIArgs(["node", "script.js", "--session-id", "sess-123"]),
     ).toBeNull();
   });
 
-  it("--session-id 無值時應回傳 null（值被當作 agent）", () => {
-    // "--session-id" 後面沒有值，"kiro" 被當作 agent，缺少 prompt
+  it("should return null when --session-id has no value (value treated as agent)", () => {
+    // "--session-id" has no value after it, "kiro" is treated as agent, missing prompt
     const result = parseCLIArgs([
       "node", "script.js", "--session-id", "kiro",
     ]);

--- a/src/wrapper/kiro-acp-ask.ts
+++ b/src/wrapper/kiro-acp-ask.ts
@@ -1,18 +1,18 @@
 #!/usr/bin/env node
 
 /**
- * ACP Wrapper — 透過 stdio 與 `openclaw acp` bridge 通訊的 ACP 客戶端。
+ * ACP Wrapper — ACP client that communicates with the `openclaw acp` bridge via stdio.
  *
- * 程式化使用：import { acpAsk } from "./kiro-acp-ask.js"
- * CLI 使用：kiro-acp-ask <agent> <prompt> [--session-id <id>]
+ * Programmatic usage: import { acpAsk } from "./kiro-acp-ask.js"
+ * CLI usage: kiro-acp-ask <agent> <prompt> [--session-id <id>]
  *
  * Exit codes:
- *   0 = 成功
+ *   0 = success
  *   1 = usage error
- *   2 = 連線失敗
+ *   2 = connection failure
  *   3 = timeout
  *
- * 所有診斷訊息輸出至 stderr，僅最終回覆文字輸出至 stdout。
+ * All diagnostic messages are output to stderr; only the final reply text is output to stdout.
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
@@ -24,17 +24,17 @@ import type {
 } from "../types/index.js";
 
 // ============================================================
-// JSON-RPC helpers（exported for testing）
+// JSON-RPC helpers (exported for testing)
 // ============================================================
 
 let _nextId = 1;
 
-/** 重設 JSON-RPC request ID 計數器（僅供測試使用）。 */
+/** Reset the JSON-RPC request ID counter (for testing only). */
 export function resetIdCounter(): void {
   _nextId = 1;
 }
 
-/** 建立 JSON-RPC 2.0 request 物件。 */
+/** Build a JSON-RPC 2.0 request object. */
 export function buildJsonRpcRequest(
   method: string,
   params?: Record<string, unknown>,
@@ -50,14 +50,14 @@ export function buildJsonRpcRequest(
   return req;
 }
 
-/** 將 JSON-RPC request 序列化為可寫入 stdin 的字串（含換行）。 */
+/** Serialize a JSON-RPC request to a string writable to stdin (with newline). */
 export function serializeRequest(req: JsonRpcRequest): string {
   return JSON.stringify(req) + "\n";
 }
 
 /**
- * 從原始 buffer 字串中解析出所有完整的 JSON-RPC response。
- * 回傳 [已解析的 responses, 剩餘未完成的 buffer]。
+ * Parse all complete JSON-RPC responses from a raw buffer string.
+ * Returns [parsed responses, remaining incomplete buffer].
  */
 export function parseResponses(
   buffer: string,
@@ -80,7 +80,7 @@ export function parseResponses(
         responses.push(parsed);
       }
     } catch {
-      // 非 JSON 行（可能是 stderr 混入），忽略
+      // Non-JSON line (possibly stderr mixed in), ignore
     }
   }
 
@@ -88,8 +88,8 @@ export function parseResponses(
 }
 
 /**
- * 判斷 JSON-RPC response 是否為 session 不存在錯誤。
- * 用於 bindSession fallback 邏輯。
+ * Determine if a JSON-RPC response is a session-not-found error.
+ * Used for bindSession fallback logic.
  */
 export function isSessionNotFoundError(response: JsonRpcResponse): boolean {
   if (!response.error) return false;
@@ -109,7 +109,7 @@ export function isSessionNotFoundError(response: JsonRpcResponse): boolean {
 }
 
 // ============================================================
-// Session 建立邏輯（exported for testing）
+// Session setup logic (exported for testing)
 // ============================================================
 
 export interface SessionSetupResult {
@@ -118,13 +118,13 @@ export interface SessionSetupResult {
 }
 
 /**
- * 產生 session 建立所需的 JSON-RPC request 序列。
+ * Generate the JSON-RPC request sequence needed for session setup.
  *
- * - 若提供 sessionId → 先嘗試 bindSession
- * - 否則 → 直接 createSession
+ * - If sessionId is provided → try bindSession first
+ * - Otherwise → createSession directly
  *
- * 回傳 [requests, expectedMethod]，其中 expectedMethod 為
- * "acp/bindSession" 或 "acp/createSession"。
+ * Returns [request, expectedMethod], where expectedMethod is
+ * "acp/bindSession" or "acp/createSession".
  */
 export function buildSessionRequests(
   agentName: string,
@@ -141,7 +141,7 @@ export function buildSessionRequests(
   return [req, "acp/createSession"];
 }
 
-/** 建立 fallback createSession request（bindSession 失敗時使用）。 */
+/** Build a fallback createSession request (used when bindSession fails). */
 export function buildFallbackCreateRequest(
   agentName: string,
 ): JsonRpcRequest {
@@ -149,12 +149,12 @@ export function buildFallbackCreateRequest(
 }
 
 /**
- * 處理 session 回應，判斷是否需要 fallback。
+ * Process session response and determine if fallback is needed.
  *
- * 回傳：
- * - { action: "ok", sessionId } — session 建立成功
- * - { action: "fallback" } — bindSession 失敗，需 fallback 至 createSession
- * - { action: "error", message } — 不可恢復的錯誤
+ * Returns:
+ * - { action: "ok", sessionId } — session established successfully
+ * - { action: "fallback" } — bindSession failed, need to fall back to createSession
+ * - { action: "error", message } — unrecoverable error
  */
 export function handleSessionResponse(
   response: JsonRpcResponse,
@@ -182,7 +182,7 @@ export function handleSessionResponse(
 }
 
 /**
- * 從 sendMessage response 中提取回覆文字。
+ * Extract reply text from a sendMessage response.
  */
 export function extractReplyText(response: JsonRpcResponse): string {
   if (response.error) {
@@ -191,7 +191,7 @@ export function extractReplyText(response: JsonRpcResponse): string {
     );
   }
   const result = response.result as Record<string, unknown> | undefined;
-  // 嘗試多種常見欄位名稱
+  // Try multiple common field names
   const text =
     (result?.text as string) ??
     (result?.content as string) ??
@@ -201,7 +201,7 @@ export function extractReplyText(response: JsonRpcResponse): string {
 }
 
 // ============================================================
-// 核心 acpAsk 函式
+// Core acpAsk function
 // ============================================================
 
 export async function acpAsk(
@@ -220,13 +220,13 @@ export async function acpAsk(
       signal: controller.signal,
     });
 
-    // 收集 stderr 供診斷
+    // Collect stderr for diagnostics
     let stderrBuf = "";
     child.stderr?.on("data", (chunk: Buffer) => {
       stderrBuf += chunk.toString();
     });
 
-    // 建立 response 收集機制
+    // Set up response collection mechanism
     let stdoutBuf = "";
     const pendingResolvers = new Map<
       number,
@@ -262,7 +262,7 @@ export async function acpAsk(
       });
     };
 
-    // 監聽子程序異常退出
+    // Listen for child process abnormal exit
     const exitPromise = new Promise<never>((_, reject) => {
       child!.on("error", (err) => {
         reject(new Error(`ACP bridge error: ${err.message}`));
@@ -312,7 +312,7 @@ export async function acpAsk(
     if (sessionResult.action === "ok") {
       actualSessionId = sessionResult.sessionId;
     } else if (sessionResult.action === "fallback") {
-      // bindSession 失敗，fallback 至 createSession
+      // bindSession failed, fall back to createSession
       process.stderr.write(
         "[acp-wrapper] bindSession failed (session not found), falling back to createSession...\n",
       );
@@ -348,18 +348,18 @@ export async function acpAsk(
 
     process.stderr.write("[acp-wrapper] Reply received.\n");
 
-    // Step 4: 嘗試 graceful shutdown（不等待回應）
+    // Step 4: attempt graceful shutdown (don't wait for response)
     try {
       const shutdownReq = buildJsonRpcRequest("shutdown");
       child.stdin?.write(serializeRequest(shutdownReq));
       child.stdin?.end();
     } catch {
-      // shutdown 失敗不影響結果
+      // Shutdown failure does not affect the result
     }
 
     return { text: replyText, sessionId: actualSessionId };
   } catch (err: unknown) {
-    // 區分 timeout vs 其他錯誤
+    // Distinguish timeout vs other errors
     if (controller.signal.aborted) {
       const timeoutErr = new Error("ACP request timed out");
       (timeoutErr as NodeJS.ErrnoException).code = "TIMEOUT";
@@ -368,7 +368,7 @@ export async function acpAsk(
     throw err;
   } finally {
     clearTimeout(timer);
-    // 確保子程序被清理
+    // Ensure child process is cleaned up
     if (child && !child.killed) {
       try {
         child.kill("SIGTERM");
@@ -383,7 +383,7 @@ export async function acpAsk(
 // CLI entry point
 // ============================================================
 
-/** 解析 CLI 參數。 */
+/** Parse CLI arguments. */
 export function parseCLIArgs(
   argv: string[],
 ): { agentName: string; prompt: string; sessionId?: string } | null {
@@ -413,7 +413,7 @@ export function parseCLIArgs(
   return { agentName, prompt, sessionId };
 }
 
-/** CLI main — 僅在直接執行時運行。 */
+/** CLI main — only runs when executed directly. */
 async function main(): Promise<void> {
   const parsed = parseCLIArgs(process.argv);
 
@@ -429,7 +429,7 @@ async function main(): Promise<void> {
 
   try {
     const result = await acpAsk({ agentName, prompt, timeoutMs, sessionId });
-    // 僅將最終回覆文字輸出至 stdout
+    // Only output the final reply text to stdout
     process.stdout.write(result.text);
   } catch (err: unknown) {
     const error = err as NodeJS.ErrnoException;
@@ -439,7 +439,7 @@ async function main(): Promise<void> {
       process.exit(3);
     }
 
-    // 連線失敗或其他錯誤
+    // Connection failure or other errors
     process.stderr.write(
       `[acp-wrapper] Error: ${error.message ?? String(err)}\n`,
     );
@@ -447,7 +447,7 @@ async function main(): Promise<void> {
   }
 }
 
-// 偵測是否為直接執行（ESM 環境）
+// Detect if running directly (ESM environment)
 const isDirectRun =
   process.argv[1] &&
   (process.argv[1].endsWith("kiro-acp-ask.js") ||


### PR DESCRIPTION
## What

Translate all Chinese comments and error messages to English in:
- `src/hook/handler.ts` and `src/hook/__tests__/handler.test.ts`
- `src/wrapper/kiro-acp-ask.ts` and `src/wrapper/__tests__/kiro-acp-ask.test.ts`

## Why

Addresses issue #8 feedback — repo should use English for an open-source project.

~226 lines changed (comments and string translations only, no logic changes).

**Depends on:** #10 (lib modules must be translated first for test consistency).