### PR TITLE
docs: translate documentation and templates to English

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,34 +1,34 @@
 # ============================================================
-# openclaw-kiro-telegram-acp skill — 環境變數範本
-# 複製此檔案為 .env 並依需求修改設定值
+# openclaw-kiro-telegram-acp skill — Environment Variable Template
+# Copy this file to .env and modify settings as needed
 # ============================================================
 
-# Kiro agent 名稱，對應 agent JSON 設定檔中的 name 欄位
-# 預設值: kiro
-# 格式: 純文字字串
+# Kiro agent name, corresponds to the name field in the agent JSON config
+# Default: kiro
+# Format: plain text string
 KIRO_AGENT_NAME=kiro
 
-# ACP 請求逾時時間（毫秒），超過此時間未收到回覆將中斷並回報逾時錯誤
-# 預設值: 120000 (2 分鐘)
-# 格式: 正整數（毫秒）
+# ACP request timeout in milliseconds; requests exceeding this time will be aborted with a timeout error
+# Default: 120000 (2 minutes)
+# Format: positive integer (milliseconds)
 KIRO_TIMEOUT_MS=120000
 
-# ACP Wrapper 可執行檔的指令名稱，用於呼叫 openclaw acp stdio bridge
-# 預設值: kiro-acp-ask
-# 格式: 可執行檔名稱或完整路徑
+# ACP Wrapper executable command name, used to invoke the openclaw acp stdio bridge
+# Default: kiro-acp-ask
+# Format: executable name or full path
 KIRO_WRAPPER_CMD=kiro-acp-ask
 
-# 允許使用 /kiro 指令的 Telegram chat ID 白名單（逗號分隔）
-# 預設值: （空字串，表示不限制任何 chat）
-# 格式: 逗號分隔的數字 ID，例如 123456789,987654321
+# Telegram chat ID allowlist for the /kiro command (comma-separated)
+# Default: (empty string, meaning no restrictions on any chat)
+# Format: comma-separated numeric IDs, e.g. 123456789,987654321
 ALLOWED_CHAT_IDS=
 
-# Kiro 回覆訊息的前綴文字，顯示於每則回覆的開頭
-# 預設值: 🤖 Kiro
-# 格式: 任意文字（支援 emoji）
+# Prefix text for Kiro reply messages, displayed at the beginning of each reply
+# Default: 🤖 Kiro
+# Format: any text (supports emoji)
 KIRO_REPLY_PREFIX=🤖 Kiro
 
-# 除錯模式開關，啟用後會在 stderr 輸出詳細診斷資訊
-# 預設值: false
-# 格式: true 或 false（亦接受 1 代表啟用）
+# Debug mode toggle; when enabled, detailed diagnostic information is output to stderr
+# Default: false
+# Format: true or false (also accepts 1 for enabled)
 KIRO_DEBUG=false

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,146 +1,146 @@
-# 安裝指南 — openclaw-kiro-telegram-acp Skill
+# Installation Guide — openclaw-kiro-telegram-acp Skill
 
-> 本文件為 `openclaw-kiro-telegram-acp` skill 的唯一安裝參考來源。
-> 所有安裝步驟皆整合於此，請依序執行。
+> This document is the single source of truth for installing the `openclaw-kiro-telegram-acp` skill.
+> All installation steps are consolidated here. Please follow them in order.
 
-## 目錄
+## Table of Contents
 
-- [前置需求](#前置需求)
-- [步驟 1：安裝依賴](#步驟-1安裝依賴)
-- [步驟 2：環境設定](#步驟-2環境設定)
-- [步驟 3：編譯專案](#步驟-3編譯專案)
-- [步驟 4：部署 Hook](#步驟-4部署-hook)
-- [步驟 5：設定 Kiro Agent](#步驟-5設定-kiro-agent)
-- [步驟 6：ACP Device Pairing](#步驟-6acp-device-pairing)
-- [步驟 7：驗證測試](#步驟-7驗證測試)
-- [從原始碼建置 Skill](#從原始碼建置-skill)
-- [已知限制：Session 隔離](#已知限制session-隔離)
-- [疑難排解：pairing required 錯誤](#疑難排解pairing-required-錯誤)
-- [自動化安裝（替代方案）](#自動化安裝替代方案)
+- [Prerequisites](#prerequisites)
+- [Step 1: Install Dependencies](#step-1-install-dependencies)
+- [Step 2: Environment Configuration](#step-2-environment-configuration)
+- [Step 3: Build the Project](#step-3-build-the-project)
+- [Step 4: Deploy the Hook](#step-4-deploy-the-hook)
+- [Step 5: Configure the Kiro Agent](#step-5-configure-the-kiro-agent)
+- [Step 6: ACP Device Pairing](#step-6-acp-device-pairing)
+- [Step 7: Validation](#step-7-validation)
+- [Building the Skill from Source](#building-the-skill-from-source)
+- [Known Limitation: Session Isolation](#known-limitation-session-isolation)
+- [Troubleshooting: pairing required Error](#troubleshooting-pairing-required-error)
+- [Automated Installation (Alternative)](#automated-installation-alternative)
 
 ---
 
-## 前置需求
+## Prerequisites
 
-安裝前請確認以下三項工具已就位，**順序很重要**：
+Before installation, confirm the following three tools are in place. **Order matters**:
 
-| 順序 | 工具 | 指令 | 用途 | 驗證方式 |
-|------|------|------|------|----------|
-| 1 | OpenClaw CLI | `openclaw` | 啟動 ACP stdio bridge、管理 hook 與 agent | `openclaw --version` |
-| 2 | kiro-cli | `kiro` | 接收 ACP 請求並產生回應的 Kiro agent 執行環境 | `kiro --version` |
-| 3 | Node.js ≥ 18 | `node` | 執行 hook、wrapper 與安裝腳本 | `node --version` |
+| Order | Tool | Command | Purpose | Verification |
+|-------|------|---------|---------|--------------|
+| 1 | OpenClaw CLI | `openclaw` | Start the ACP stdio bridge, manage hooks and agents | `openclaw --version` |
+| 2 | kiro-cli | `kiro` | Kiro agent runtime that receives ACP requests and generates responses | `kiro --version` |
+| 3 | Node.js ≥ 18 | `node` | Run hooks, wrapper, and install scripts | `node --version` |
 
-### 檢查前置需求
+### Check Prerequisites
 
 ```bash
-# 1. 確認 openclaw 已安裝
+# 1. Confirm openclaw is installed
 openclaw --version
-# 預期結果：顯示版本號，例如 2026.4.2
+# Expected: displays version number, e.g. 2026.4.2
 
-# 2. 確認 kiro-cli 已安裝
+# 2. Confirm kiro-cli is installed
 kiro --version
-# 預期結果：顯示 kiro-cli 版本號
+# Expected: displays kiro-cli version number
 
-# 3. 確認 Node.js 版本 ≥ 18
+# 3. Confirm Node.js version ≥ 18
 node --version
-# 預期結果：v18.x.x 或更高版本
+# Expected: v18.x.x or higher
 ```
 
-> **重要**：`openclaw` 必須先就位，因為 ACP pairing 與 scope 驗證都需要透過 `openclaw` 執行。`kiro-cli` 是 `openclaw acp` bridge 的下游目標，若 `kiro` 不在 PATH 中，ACP bridge 無法建立連線，整個 skill 將無法運作。
+> **Important**: `openclaw` must be in place first, as ACP pairing and scope verification both require `openclaw`. `kiro-cli` is the downstream target of the `openclaw acp` bridge — if `kiro` is not in PATH, the ACP bridge cannot establish a connection and the entire skill will not work.
 
-若缺少任一工具：
+If any tool is missing:
 
-- **OpenClaw**：請參閱 OpenClaw 官方文件進行安裝
-- **kiro-cli**：請至 [https://kiro.dev/docs/installation](https://kiro.dev/docs/installation) 安裝，安裝後確認 `kiro --version` 可正常執行
-- **Node.js**：請至 [https://nodejs.org/](https://nodejs.org/) 下載 LTS 版本（≥ 18）
+- **OpenClaw**: Refer to the official OpenClaw documentation for installation
+- **kiro-cli**: Install from [https://kiro.dev/docs/installation](https://kiro.dev/docs/installation), then confirm `kiro --version` works
+- **Node.js**: Download the LTS version (≥ 18) from [https://nodejs.org/](https://nodejs.org/)
 
 ---
 
-## 步驟 1：安裝依賴
+## Step 1: Install Dependencies
 
 ```bash
-# 進入專案目錄
+# Navigate to the project directory
 cd openclaw-kiro-telegram-acp
 
-# 安裝所有 npm 依賴
+# Install all npm dependencies
 npm install
 ```
 
-**預期結果**：`node_modules/` 目錄建立完成，無錯誤訊息。終端機顯示已安裝的套件數量。
+**Expected result**: The `node_modules/` directory is created with no errors. The terminal displays the number of installed packages.
 
 ---
 
-## 步驟 2：環境設定
+## Step 2: Environment Configuration
 
-複製環境變數範本並依需求修改：
+Copy the environment variable template and modify as needed:
 
 ```bash
 cp .env.example .env
 ```
 
-編輯 `.env` 檔案，設定以下變數：
+Edit the `.env` file and set the following variables:
 
 ```dotenv
-# Kiro agent 名稱，對應 agent JSON 設定檔中的 name 欄位
-# 預設值: kiro
+# Kiro agent name, corresponds to the name field in the agent JSON config
+# Default: kiro
 KIRO_AGENT_NAME=kiro
 
-# ACP 請求逾時時間（毫秒）
-# 預設值: 120000 (2 分鐘)
+# ACP request timeout in milliseconds
+# Default: 120000 (2 minutes)
 KIRO_TIMEOUT_MS=120000
 
-# ACP Wrapper 可執行檔的指令名稱
-# 預設值: kiro-acp-ask
+# ACP Wrapper executable command name
+# Default: kiro-acp-ask
 KIRO_WRAPPER_CMD=kiro-acp-ask
 
-# 允許使用 /kiro 指令的 Telegram chat ID 白名單（逗號分隔）
-# 留空表示不限制
+# Telegram chat ID allowlist for the /kiro command (comma-separated)
+# Leave empty for no restrictions
 ALLOWED_CHAT_IDS=
 
-# Kiro 回覆訊息的前綴文字
-# 預設值: 🤖 Kiro
+# Prefix text for Kiro reply messages
+# Default: 🤖 Kiro
 KIRO_REPLY_PREFIX=🤖 Kiro
 
-# 除錯模式（true/false）
+# Debug mode (true/false)
 KIRO_DEBUG=false
 ```
 
-**預期結果**：`.env` 檔案已建立，至少 `KIRO_AGENT_NAME` 已設定為你的 Kiro agent 名稱。
+**Expected result**: The `.env` file is created, with at least `KIRO_AGENT_NAME` set to your Kiro agent name.
 
-> 各變數的詳細說明請參閱 `.env.example`（路徑：[.env.example](.env.example)）。
+> For detailed descriptions of each variable, see `.env.example` (path: [.env.example](.env.example)).
 
 ---
 
-## 步驟 3：編譯專案
+## Step 3: Build the Project
 
 ```bash
 npm run build
 ```
 
-**預期結果**：TypeScript 編譯完成，`dist/` 目錄產生對應的 JavaScript 檔案，終端機無錯誤輸出。
+**Expected result**: TypeScript compilation completes, the `dist/` directory contains the corresponding JavaScript files, and the terminal shows no errors.
 
 ---
 
-## 步驟 4：部署 Hook
+## Step 4: Deploy the Hook
 
-Hook 檔案的**唯一部署路徑**為：
+The **only deployment path** for hook files is:
 
 ```
 ~/.openclaw/workspace/hooks/
 ```
 
-> ⚠️ **請勿**將 hook 放置於 `~/.openclaw/hooks/`（managed 路徑）。若同一 hook 名稱同時存在於 managed 與 workspace 路徑，workspace 的副本會被忽略，可能導致執行過時的程式碼。
+> ⚠️ **Do not** place hooks in `~/.openclaw/hooks/` (managed path). If the same hook name exists in both managed and workspace paths, the workspace copy will be ignored, potentially causing outdated code to run.
 
-### 手動部署
+### Manual Deployment
 
 ```bash
-# 建立 hook 目錄
+# Create the hook directory
 mkdir -p ~/.openclaw/workspace/hooks/kiro-command
 
-# 複製編譯後的 hook handler
+# Copy the compiled hook handler
 cp dist/hook/handler.js ~/.openclaw/workspace/hooks/kiro-command/handler.ts
 
-# 建立 HOOK.md 設定檔
+# Create the HOOK.md configuration file
 cat > ~/.openclaw/workspace/hooks/kiro-command/HOOK.md << 'EOF'
 ---
 name: kiro-command
@@ -155,31 +155,31 @@ metadata:
 EOF
 ```
 
-### 啟用 Hook
+### Enable the Hook
 
 ```bash
 openclaw hooks enable kiro-command
 ```
 
-**預期結果**：執行 `openclaw hooks list` 時，`kiro-command` 顯示為已啟用狀態（非 `⏸ disabled`）。
+**Expected result**: When running `openclaw hooks list`, `kiro-command` shows as enabled (not `⏸ disabled`).
 
 ---
 
-## 步驟 5：設定 Kiro Agent
+## Step 5: Configure the Kiro Agent
 
-### 建立 Agent 設定檔
+### Create the Agent Configuration File
 
-以 `templates/kiro-agent.json`（路徑：[templates/kiro-agent.json](templates/kiro-agent.json)）為範本，建立你的 agent 設定：
+Use `templates/kiro-agent.json` (path: [templates/kiro-agent.json](templates/kiro-agent.json)) as a template to create your agent configuration:
 
 ```bash
-# 建立 kiro-settings 目錄
+# Create the kiro-settings directory
 mkdir -p ~/.openclaw/workspace/kiro-settings
 
-# 複製範本
+# Copy the template
 cp templates/kiro-agent.json ~/.openclaw/workspace/kiro-settings/kiro_default.json
 ```
 
-範本內容：
+Template contents:
 
 ```json
 {
@@ -193,260 +193,260 @@ cp templates/kiro-agent.json ~/.openclaw/workspace/kiro-settings/kiro_default.js
 }
 ```
 
-### 設定 KB 檔案
+### Configure KB Files
 
-將你的 Knowledge Base（知識庫）markdown 檔案放置於適當位置，並更新 `resources` 陣列中的路徑。路徑使用相對格式（以 `./` 開頭），OpenClaw 會自動解析。
+Place your Knowledge Base markdown files in the appropriate location and update the paths in the `resources` array. Paths use relative format (starting with `./`), and OpenClaw will resolve them automatically.
 
-範例 KB 檔案可參考 `templates/kb-example.md`（路徑：[templates/kb-example.md](templates/kb-example.md)）。
+For an example KB file, see `templates/kb-example.md` (path: [templates/kb-example.md](templates/kb-example.md)).
 
-**預期結果**：`~/.openclaw/workspace/kiro-settings/kiro_default.json` 已建立，`name` 欄位與 `.env` 中的 `KIRO_AGENT_NAME` 一致，`resources` 指向實際存在的 KB 檔案。
+**Expected result**: `~/.openclaw/workspace/kiro-settings/kiro_default.json` is created, the `name` field matches `KIRO_AGENT_NAME` in `.env`, and `resources` points to existing KB files.
 
 ---
 
-## 步驟 6：ACP Device Pairing
+## Step 6: ACP Device Pairing
 
-ACP 通訊需要完成 device pairing 並核准所需的 scopes。未完成 pairing 的 device 可能僅有 `operator.read` 權限，不足以進行 ACP 操作。
+ACP communication requires completing device pairing and approving the required scopes. An unpaired device may only have `operator.read` permissions, which are insufficient for ACP operations.
 
-### 6.1 檢查目前 Device 狀態
+### 6.1 Check Current Device Status
 
 ```bash
 openclaw devices list
 ```
 
-**預期結果**：顯示已註冊的 device 清單及其狀態。確認你的 device 是否已列出。
+**Expected result**: Displays the list of registered devices and their status. Confirm whether your device is listed.
 
-### 6.2 發起 Pairing 請求
+### 6.2 Initiate Pairing Request
 
-若 device 尚未 pair，執行：
+If the device is not yet paired, run:
 
 ```bash
 openclaw acp pair
 ```
 
-**預期結果**：終端機顯示 pairing 請求已發送，等待 approve。
+**Expected result**: The terminal shows that the pairing request has been sent, awaiting approval.
 
 ### 6.3 Approve Device
 
-核准最新的 device 請求：
+Approve the latest device request:
 
 ```bash
 openclaw devices approve --latest
 ```
 
-**預期結果**：終端機顯示 device 已核准。
+**Expected result**: The terminal shows the device has been approved.
 
-### 6.4 確認 Scopes
+### 6.4 Confirm Scopes
 
-確認 device 已取得 ACP 操作所需的 scopes：
+Confirm the device has the required scopes for ACP operations:
 
 ```bash
 openclaw devices list
 ```
 
-**預期結果**：你的 device 狀態顯示為已核准，且 scopes 包含 ACP 操作所需的權限（不僅僅是 `operator.read`）。
+**Expected result**: Your device status shows as approved, and scopes include the permissions required for ACP operations (not just `operator.read`).
 
-> 若 scope 不足，可能需要重新執行 pairing 流程或聯繫管理員調整權限。
+> If scopes are insufficient, you may need to re-run the pairing flow or contact an administrator to adjust permissions.
 
 ---
 
-## 步驟 7：驗證測試
+## Step 7: Validation
 
-### 使用 Health Checker 自動驗證
+### Automated Validation with Health Checker
 
 ```bash
 npm run validate
 ```
 
-Health Checker 會依序檢查以下項目：
+The Health Checker will sequentially verify the following items:
 
-1. `kiro-cli` 可用性
-2. `openclaw` CLI 可用性
-3. Hook 檔案存在且已啟用
-4. Agent 設定檔格式正確
-5. ACP Wrapper 可執行
-6. 環境變數已設定
-7. ACP device pairing 狀態
+1. `kiro-cli` availability
+2. `openclaw` CLI availability
+3. Hook file exists and is enabled
+4. Agent configuration file format is correct
+5. ACP Wrapper is executable
+6. Environment variables are set
+7. ACP device pairing status
 
-**預期結果**：所有檢查項目顯示 `✓` 通過。若有失敗項目，Health Checker 會提供具體的修復建議。
+**Expected result**: All check items show `✓` passed. If any item fails, the Health Checker will provide specific fix suggestions.
 
-### 端對端測試
+### End-to-End Test
 
-在 Telegram 中發送：
+In Telegram, send:
 
 ```
 /kiro hi
 ```
 
-**預期結果**：
+**Expected result**:
 
-- Kiro 回覆一則訊息（帶有 `🤖 Kiro` 前綴）
-- OpenClaw 主 agent **不會**同時回覆
-- 發送空的 `/kiro`（不帶任何文字）會回傳簡短的使用提示
+- Kiro replies with a message (prefixed with `🤖 Kiro`)
+- The main OpenClaw agent does **not** reply simultaneously
+- Sending an empty `/kiro` (without any text) returns a brief usage hint
 
 ---
 
-## 從原始碼建置 Skill
+## Building the Skill from Source
 
-若你需要從原始碼重新建置 `.skill` 檔案（而非使用 repo 中預先打包的版本）：
+If you need to rebuild the `.skill` file from source (instead of using the pre-packaged version in the repo):
 
 ```bash
-# 1. 確認依賴已安裝
+# 1. Ensure dependencies are installed
 npm install
 
-# 2. 編譯 TypeScript
+# 2. Compile TypeScript
 npm run build
 
-# 3. 建置 .skill 檔案
+# 3. Build the .skill file
 npm run build-skill
 ```
 
-**預期結果**：終端機輸出產生的 `.skill` 檔案路徑與大小。建置後的 skill 檔案位於專案根目錄（`kiro-telegram-acp.skill`）。
+**Expected result**: The terminal outputs the generated `.skill` file path and size. The built skill file is located in the project root (`kiro-telegram-acp.skill`).
 
-建置流程會自動執行：
-1. TypeScript 編譯
-2. 將編譯後的 JS 與資源檔案複製至 `skill-src/`
-3. 打包為 `.skill` 檔案
+The build process automatically performs:
+1. TypeScript compilation
+2. Copies compiled JS and resource files to `skill-src/`
+3. Packages into a `.skill` file
 
-> 建置腳本原始碼位於 `scripts/build-skill.ts`（路徑：[scripts/build-skill.ts](scripts/build-skill.ts)）。
+> The build script source is at `scripts/build-skill.ts` (path: [scripts/build-skill.ts](scripts/build-skill.ts)).
 
 ---
 
-## 已知限制：Session 隔離
+## Known Limitation: Session Isolation
 
-### 限制說明
+### Description
 
-OpenClaw 的 `message:received` hook 機制存在以下已知限制：
+The OpenClaw `message:received` hook mechanism has the following known limitations:
 
-1. **`message:received` hook 無法阻止訊息進入主 agent 的 context window**。即使 hook 攔截了 `/kiro` 訊息並交由 Kiro 處理，該訊息內容仍可能被主 agent 看到並納入其對話歷史。
+1. **`message:received` hook cannot prevent messages from entering the main agent's context window**. Even if the hook intercepts a `/kiro` message and routes it to Kiro, the message content may still be visible to the main agent and included in its conversation history.
 
-2. **`message:received` 是 void hook**。在 OpenClaw 2026.4.2 中，此 hook 的回傳值會被丟棄，`{ suppress: true }` 不會生效。
+2. **`message:received` is a void hook**. In OpenClaw 2026.4.2, the return value of this hook is discarded; `{ suppress: true }` has no effect.
 
-3. **kiro-cli 重啟後 session 可能消失**。ACP Wrapper 會自動透過 `acp/createSession` 重建 session，但先前的對話記憶將從此次重新開始。
+3. **Sessions may disappear after kiro-cli restarts**. The ACP Wrapper will automatically rebuild the session via `acp/createSession`, but previous conversation memory will start fresh from that point.
 
-4. **同一 chat 內的所有 `/kiro` 訊息共享同一個 session**（格式：`kiro-telegram-{chatId}`）。這是設計上的選擇，用於實現跨訊息記憶。不同 Telegram chat 之間的 Kiro session 則是完全獨立的。
+4. **All `/kiro` messages within the same chat share a single session** (format: `kiro-telegram-{chatId}`). This is by design to enable cross-message memory. Kiro sessions across different Telegram chats are fully isolated.
 
-### 替代方案：SOUL.md 指令
+### Alternative: SOUL.md Directive
 
-為了補強 hook 層級的隔離不足，請在你的 `SOUL.md` 中加入以下指令：
+To supplement the insufficient isolation at the hook level, add the following directive to your `SOUL.md`:
 
 ```markdown
 If a message starts with `/kiro`, ignore it completely. Do not reply. That command is handled by a separate Kiro agent via a hook.
 ```
 
-這會指示主 agent 在行為層面忽略 `/kiro` 訊息，作為 hook 機制的安全網。即使 `/kiro` 訊息進入了主 agent 的 context，主 agent 也不會對其產生回覆或引用其內容。
+This instructs the main agent to ignore `/kiro` messages at the behavioral level, serving as a safety net for the hook mechanism. Even if a `/kiro` message enters the main agent's context, the main agent will not reply to or reference its content.
 
-> **建議**：同時使用 `message:sending` hook 的 `{ cancel: true }` 回傳值與 `SOUL.md` 指令，形成雙重保護機制。
+> **Recommendation**: Use both the `message:sending` hook's `{ cancel: true }` return value and the `SOUL.md` directive for dual-layer protection.
 
 ---
 
-## 疑難排解：pairing required 錯誤
+## Troubleshooting: pairing required Error
 
-當你看到以下錯誤時：
+When you see the following error:
 
 ```
 GatewayClientRequestError: pairing required
 ```
 
-或 Kiro 回覆：
+Or Kiro replies:
 
 ```
-🔐 需要完成 device pairing，請參閱安裝指南。
+🔐 Device pairing required. Please refer to the installation guide.
 ```
 
-請依照以下步驟逐一排除：
+Follow these steps to troubleshoot:
 
-### 步驟 1：確認 Device 狀態
+### Step 1: Check Device Status
 
 ```bash
 openclaw devices list
 ```
 
-檢查你的 device 是否已列出，以及其狀態是否為已核准。
+Check whether your device is listed and whether its status is approved.
 
-**若 device 未列出**：表示尚未進行 pairing，請繼續步驟 2。
+**If the device is not listed**: Pairing has not been performed yet. Continue to Step 2.
 
-**若 device 已列出但狀態為 pending**：表示 pairing 請求尚未被核准，請跳至步驟 3。
+**If the device is listed but status is pending**: The pairing request has not been approved yet. Skip to Step 3.
 
-### 步驟 2：發起 Pairing 請求
+### Step 2: Initiate Pairing Request
 
 ```bash
 openclaw acp pair
 ```
 
-**預期結果**：終端機顯示 pairing 請求已發送。
+**Expected result**: The terminal shows the pairing request has been sent.
 
-### 步驟 3：Approve Device
+### Step 3: Approve Device
 
 ```bash
 openclaw devices approve --latest
 ```
 
-**預期結果**：終端機顯示 device 已核准。
+**Expected result**: The terminal shows the device has been approved.
 
-### 步驟 4：確認 Scopes 足夠
+### Step 4: Confirm Sufficient Scopes
 
 ```bash
 openclaw devices list
 ```
 
-確認 device 的 scopes 不僅僅是 `operator.read`。ACP 操作需要額外的 scope 權限。
+Confirm the device's scopes are not limited to just `operator.read`. ACP operations require additional scope permissions.
 
-**若 scope 不足**：可能需要重新執行 pairing 流程，或聯繫管理員調整權限設定。
+**If scopes are insufficient**: You may need to re-run the pairing flow or contact an administrator to adjust permission settings.
 
-### 步驟 5：重新測試
+### Step 5: Re-test
 
 ```bash
-# 使用 Health Checker 驗證
+# Validate with Health Checker
 npm run validate
 
-# 或直接在 Telegram 測試
-# 發送：/kiro hi
+# Or test directly in Telegram
+# Send: /kiro hi
 ```
 
-**預期結果**：`pairing required` 錯誤不再出現，Kiro 正常回覆。
+**Expected result**: The `pairing required` error no longer appears, and Kiro responds normally.
 
-> 若以上步驟皆無法解決問題，請確認 `openclaw` 版本是否為 2026.4.2 或相容版本，並檢查網路連線是否正常。
+> If none of the above steps resolve the issue, confirm that the `openclaw` version is 2026.4.2 or a compatible version, and check that the network connection is working properly.
 
 ---
 
-## 自動化安裝（替代方案）
+## Automated Installation (Alternative)
 
-若你偏好自動化流程，可使用內建的互動式安裝腳本：
+If you prefer an automated flow, use the built-in interactive install script:
 
 ```bash
-# 先編譯安裝腳本
+# First build the install script
 npm install
 npm run build
 
-# 執行自動化安裝
+# Run the automated installation
 npm run install-skill
 ```
 
-安裝腳本會自動執行以下流程：
+The install script will automatically perform the following:
 
-1. 檢查 `openclaw` CLI 可用性
-2. 檢查 `kiro-cli` 可用性（若未找到會立即停止並提示安裝）
-3. 檢查 Node.js 版本 ≥ 18
-4. 執行 `npm install`
-5. 引導設定 `.env` 環境變數（提供預設值與輸入提示）
-6. 編譯 TypeScript
-7. 部署 hook 至 `~/.openclaw/workspace/hooks/`
-8. 產生 agent config JSON
-9. 輸出安裝摘要與下一步指引
+1. Check `openclaw` CLI availability
+2. Check `kiro-cli` availability (stops immediately with install instructions if not found)
+3. Check Node.js version ≥ 18
+4. Run `npm install`
+5. Guide `.env` environment variable setup (with defaults and input prompts)
+6. Compile TypeScript
+7. Deploy hook to `~/.openclaw/workspace/hooks/`
+8. Generate agent config JSON
+9. Output installation summary and next steps
 
-**預期結果**：安裝腳本完成後顯示安裝摘要，列出已完成的步驟與下一步操作（如 ACP device pairing）。
+**Expected result**: After the install script completes, it displays an installation summary listing completed steps and next actions (such as ACP device pairing).
 
-> 若任一步驟失敗，腳本會停止執行並輸出已完成的步驟與失敗原因。
+> If any step fails, the script will stop and output the completed steps along with the failure reason.
 
 ---
 
-## 相關文件
+## Related Documents
 
-| 文件 | 路徑 | 說明 |
-|------|------|------|
-| 架構概覽 | [docs/architecture.md](docs/architecture.md) | 端對端訊息流程與系統架構 |
-| 部署指南 | [docs/deployment.md](docs/deployment.md) | 詳細部署步驟與疑難排解（本文件為其統一替代） |
-| Wrapper 合約 | [docs/wrapper-contract.md](docs/wrapper-contract.md) | ACP Wrapper 的 stdout/stderr 合約規範 |
-| 環境變數範本 | [.env.example](.env.example) | 所有可設定的環境變數與說明 |
-| Agent 設定範本 | [templates/kiro-agent.json](templates/kiro-agent.json) | Kiro agent JSON 設定範本 |
-| KB 範例 | [templates/kb-example.md](templates/kb-example.md) | 範例 Knowledge Base 檔案 |
+| Document | Path | Description |
+|----------|------|-------------|
+| Architecture Overview | [docs/architecture.md](docs/architecture.md) | End-to-end message flow and system architecture |
+| Deployment Guide | [docs/deployment.md](docs/deployment.md) | Detailed deployment steps and troubleshooting (this document is the unified replacement) |
+| Wrapper Contract | [docs/wrapper-contract.md](docs/wrapper-contract.md) | ACP Wrapper stdout/stderr contract specification |
+| Environment Variable Template | [.env.example](.env.example) | All configurable environment variables with descriptions |
+| Agent Config Template | [templates/kiro-agent.json](templates/kiro-agent.json) | Kiro agent JSON configuration template |
+| KB Example | [templates/kb-example.md](templates/kb-example.md) | Example Knowledge Base file |

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 # openclaw-kiro-telegram-acp
 
-透過 Telegram `/kiro` 指令，將使用者的訊息經由 OpenClaw ACP bridge 轉發至下游 Kiro agent，並將回覆傳回 Telegram。
+Relay user messages from Telegram via the `/kiro` command through the OpenClaw ACP bridge to a downstream Kiro agent, and send the reply back to Telegram.
 
 ```text
 Telegram → OpenClaw Hook → ACP Wrapper → openclaw acp (stdio bridge) → Kiro Agent → Telegram
 ```
 
-## 功能特色
+## Features
 
-- 🤖 **Telegram `/kiro` 指令** — 在 Telegram 中直接與 Kiro agent 對話
-- 🔀 **雙重回覆抑制** — `message:received` 攔截指令，`message:sending` 以 `{ cancel: true }` 取消主 agent 回覆
-- 🧠 **跨訊息記憶** — 同一 chat 的 `/kiro` 對話共享固定 session，Kiro 能記住先前的對話內容
-- 🔒 **Chat ID 白名單** — 限制僅允許信任的 Telegram 使用者存取
-- 🛡️ **錯誤訊息格式化** — JSON-RPC error、provider error、ACP 權限錯誤皆轉換為使用者友善的訊息
-- ⚡ **非同步非阻塞** — 使用 `execFile` 避免凍結 gateway event loop
-- 📦 **OpenClaw Skill 封裝** — 可透過 `skill-src/` 或 ClawHub 安裝
-- 🔧 **環境變數設定** — agent 名稱、timeout、chat 白名單、回覆前綴皆可透過 `.env` 調整
+- 🤖 **Telegram `/kiro` command** — Chat with the Kiro agent directly in Telegram
+- 🔀 **Dual reply suppression** — `message:received` intercepts the command, `message:sending` cancels the main agent reply with `{ cancel: true }`
+- 🧠 **Cross-message memory** — `/kiro` conversations within the same chat share a fixed session, allowing Kiro to remember previous context
+- 🔒 **Chat ID allowlist** — Restrict access to trusted Telegram users only
+- 🛡️ **Error message formatting** — JSON-RPC errors, provider errors, and ACP permission errors are converted to user-friendly messages
+- ⚡ **Async non-blocking** — Uses `execFile` to avoid freezing the gateway event loop
+- 📦 **OpenClaw Skill packaging** — Installable via `skill-src/` or ClawHub
+- 🔧 **Environment variable configuration** — Agent name, timeout, chat allowlist, and reply prefix are all configurable via `.env`
 
-## 快速開始
+## Quick Start
 
-完整的安裝步驟請參閱 **[INSTALL.md](INSTALL.md)**。
+For complete installation steps, see **[INSTALL.md](INSTALL.md)**.
 
-若偏好自動化流程，可使用內建的互動式安裝腳本：
+If you prefer an automated flow, use the built-in interactive install script:
 
 ```bash
 npm install
@@ -29,43 +29,43 @@ npm run build
 npm run install-skill
 ```
 
-安裝後執行驗證：
+After installation, run validation:
 
 ```bash
 npm run validate
 ```
 
-## 相容性說明
+## Compatibility Notes
 
-本專案針對 OpenClaw `2026.4.2` 開發，其中 `openclaw acp` 為 **stdio JSON-RPC bridge**（非 HTTP server，亦非 one-shot `ask` 指令）。
+This project is developed for OpenClaw `2026.4.2`, where `openclaw acp` is a **stdio JSON-RPC bridge** (not an HTTP server, nor a one-shot `ask` command).
 
-## 專案結構
+## Project Structure
 
 ```text
 .
-├── INSTALL.md                      # 統一安裝指南（唯一安裝參考來源）
-├── .env.example                    # 環境變數範本
+├── INSTALL.md                      # Unified installation guide (single source of truth)
+├── .env.example                    # Environment variable template
 ├── src/
 │   ├── hook/handler.ts             # OpenClaw Hook handler
-│   ├── wrapper/kiro-acp-ask.ts     # ACP Wrapper 實作
-│   └── lib/                        # 核心模組（config、error-formatter 等）
-├── scripts/                        # 自動化腳本（install、validate、build-skill）
-├── templates/                      # Agent config 與 KB 範本
-├── skill-src/                      # Skill 原始碼（打包用）
-├── docs/                           # 架構、部署、wrapper 合約文件
-└── examples/                       # 範例檔案
+│   ├── wrapper/kiro-acp-ask.ts     # ACP Wrapper implementation
+│   └── lib/                        # Core modules (config, error-formatter, etc.)
+├── scripts/                        # Automation scripts (install, validate, build-skill)
+├── templates/                      # Agent config and KB templates
+├── skill-src/                      # Skill source code (for packaging)
+├── docs/                           # Architecture, deployment, wrapper contract docs
+└── examples/                       # Example files
 ```
 
-## 相關文件
+## Related Documents
 
-| 文件 | 說明 |
-|------|------|
-| [INSTALL.md](INSTALL.md) | 統一安裝指南 — 前置需求、環境設定、hook 部署、ACP pairing、驗證測試 |
-| [docs/architecture.md](docs/architecture.md) | 端對端訊息流程與系統架構 |
-| [docs/wrapper-contract.md](docs/wrapper-contract.md) | ACP Wrapper 的 stdout/stderr 合約規範 |
-| [docs/deployment.md](docs/deployment.md) | 部署步驟與疑難排解 |
-| [.env.example](.env.example) | 所有可設定的環境變數與說明 |
-| [templates/kiro-agent.json](templates/kiro-agent.json) | Kiro agent JSON 設定範本 |
+| Document | Description |
+|----------|-------------|
+| [INSTALL.md](INSTALL.md) | Unified installation guide — prerequisites, environment setup, hook deployment, ACP pairing, validation |
+| [docs/architecture.md](docs/architecture.md) | End-to-end message flow and system architecture |
+| [docs/wrapper-contract.md](docs/wrapper-contract.md) | ACP Wrapper stdout/stderr contract specification |
+| [docs/deployment.md](docs/deployment.md) | Deployment steps and troubleshooting |
+| [.env.example](.env.example) | All configurable environment variables with descriptions |
+| [templates/kiro-agent.json](templates/kiro-agent.json) | Kiro agent JSON configuration template |
 
 ## License
 

--- a/templates/kb-example.md
+++ b/templates/kb-example.md
@@ -1,49 +1,49 @@
 # Kiro Agent Knowledge Base
 
-> 這是一個範例 KB（Knowledge Base）檔案。Kiro agent 會在回答問題時參考此檔案的內容。
-> 請根據你的需求自訂以下內容，或新增更多 KB 檔案並在 `kiro-agent.json` 的 `resources` 陣列中加入路徑。
+> This is an example KB (Knowledge Base) file. The Kiro agent will reference the contents of this file when answering questions.
+> Customize the content below to suit your needs, or add more KB files and include their paths in the `resources` array of `kiro-agent.json`.
 
-## 關於此 Agent
+## About This Agent
 
-- 名稱：Kiro
-- 用途：透過 Telegram `/kiro` 指令回答使用者問題
-- 語言偏好：繁體中文（可依需求調整）
+- Name: Kiro
+- Purpose: Answer user questions via the Telegram `/kiro` command
+- Language preference: English (adjustable as needed)
 
-## 常見問答
+## FAQ
 
-### Q: 這個 bot 能做什麼？
+### Q: What can this bot do?
 
-Kiro 是一個透過 OpenClaw 平台運作的 AI 助手。你可以在 Telegram 中使用 `/kiro` 指令向它提問，例如：
+Kiro is an AI assistant that operates through the OpenClaw platform. You can ask it questions in Telegram using the `/kiro` command, for example:
 
-- `/kiro 今天天氣如何？`
-- `/kiro 幫我解釋什麼是 ACP`
-- `/kiro 用 Python 寫一個 hello world`
+- `/kiro What's the weather like today?`
+- `/kiro Explain what ACP is`
+- `/kiro Write a hello world in Python`
 
-### Q: 如何新增自訂知識？
+### Q: How do I add custom knowledge?
 
-1. 建立一個新的 markdown 檔案（例如 `templates/my-knowledge.md`）
-2. 在 `kiro-agent.json` 的 `resources` 陣列中加入該檔案的相對路徑
-3. 重新載入 agent 設定
+1. Create a new markdown file (e.g. `templates/my-knowledge.md`)
+2. Add the relative path of that file to the `resources` array in `kiro-agent.json`
+3. Reload the agent configuration
 
-## 自訂規則
+## Custom Rules
 
-<!-- 在此新增你希望 agent 遵守的規則，例如： -->
+<!-- Add rules you want the agent to follow here, for example: -->
 
-- 回答時保持簡潔，避免過長的回覆
-- 遇到不確定的問題時，誠實告知使用者
-- 不回答涉及個人隱私或敏感資訊的問題
+- Keep answers concise and avoid overly long replies
+- When uncertain about a question, honestly inform the user
+- Do not answer questions involving personal privacy or sensitive information
 
-## 領域知識
+## Domain Knowledge
 
-<!-- 在此新增你的專業領域知識，例如： -->
+<!-- Add your domain-specific knowledge here, for example: -->
 
-### 專案資訊
+### Project Information
 
-- 專案名稱：（填入你的專案名稱）
-- 技術棧：（填入你使用的技術）
-- 文件位置：（填入相關文件的路徑或連結）
+- Project name: (fill in your project name)
+- Tech stack: (fill in the technologies you use)
+- Documentation location: (fill in paths or links to relevant docs)
 
-### 團隊慣例
+### Team Conventions
 
-- 程式碼風格：（填入你的團隊慣例）
-- 部署流程：（填入部署相關資訊）
+- Code style: (fill in your team conventions)
+- Deployment process: (fill in deployment-related information)

--- a/templates/kiro-agent.json
+++ b/templates/kiro-agent.json
@@ -1,6 +1,6 @@
 {
   "_comments": {
-    "resources": "在 resources 陣列中加入你自己的 KB 檔案路徑（相對於 OpenClaw workspace 根目錄）。例如：'./templates/my-kb.md' 或 './docs/my-guide.md'。路徑必須使用相對路徑格式（以 ./ 開頭），OpenClaw 會自動解析。部署前請確認檔案存在於指定路徑。"
+    "resources": "Add your own KB file paths to the resources array (relative to the OpenClaw workspace root). For example: './templates/my-kb.md' or './docs/my-guide.md'. Paths must use relative format (starting with ./), and OpenClaw will resolve them automatically. Ensure the files exist at the specified paths before deployment."
   },
   "name": "kiro",
   "description": "Kiro agent for Telegram relay",


### PR DESCRIPTION
Translate README.md, INSTALL.md, .env.example, templates/kb-example.md, templates/kiro-agent.json to English. Addresses issue #8. ~264 lines.