### PR TITLE
refactor: remove remaining ACP wrapper references (post-rebase)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -253,21 +253,14 @@ openclaw devices list
 npm run validate
 ```
 
-若你只是 clone 下來做開發或跑 CI（尚未安裝到 OpenClaw workspace），可用 dev 模式跳過 workspace/安裝檢查：
-
-```bash
-npm run validate -- --mode=dev
-```
-
 Health Checker 會依序檢查以下項目：
 
 1. `kiro-cli` 可用性
 2. `openclaw` CLI 可用性
 3. Hook 檔案存在且已啟用
 4. Agent 設定檔格式正確
-5. ACP Wrapper 可執行
-6. 環境變數已設定
-7. ACP device pairing 狀態
+5. 環境變數已設定
+6. ACP device pairing 狀態
 
 **預期結果**：所有檢查項目顯示 `✓` 通過。若有失敗項目，Health Checker 會提供具體的修復建議。
 
@@ -323,7 +316,7 @@ OpenClaw 的 `message:received` hook 機制存在以下已知限制：
 
 2. **`message:received` 是 void hook**。在 OpenClaw 2026.4.2 中，此 hook 的回傳值會被丟棄，`{ suppress: true }` 不會生效。
 
-3. **kiro-cli 重啟後 session 可能消失**。ACP Wrapper 會自動透過 `acp/createSession` 重建 session，但先前的對話記憶將從此次重新開始。
+3. **kiro-cli 重啟後 session 可能消失**。Agent 會自動重建 session，但先前的對話記憶將從此次重新開始。
 
 4. **同一 chat 內的所有 `/kiro` 訊息共享同一個 session**（格式：`kiro-telegram-{chatId}`）。這是設計上的選擇，用於實現跨訊息記憶。不同 Telegram chat 之間的 Kiro session 則是完全獨立的。
 

--- a/docs/masami-steering.md
+++ b/docs/masami-steering.md
@@ -54,14 +54,12 @@ chore: 雜務（CI、build config）
 這兩個資料夾的共用檔案必須保持一致：
 
 - `hook-template.ts`
-- `kiro-acp-ask.js`
 - `kiro-agent-template.json`
 
 改了其中一邊，必須同步另一邊。每次 commit 前執行：
 
 ```bash
 diff examples/hook-template.ts skill-src/kiro-telegram-acp/references/hook-template.ts
-diff examples/kiro-acp-ask.js skill-src/kiro-telegram-acp/references/kiro-acp-ask.js
 diff examples/kiro-agent-template.json skill-src/kiro-telegram-acp/references/kiro-agent-template.json
 ```
 
@@ -95,7 +93,7 @@ diff -r /tmp/skill-verify/ skill-src/kiro-telegram-acp/
 
 ### 可執行腳本
 
-- CLI wrapper（如 `kiro-acp-ask.js`）必須有 executable 權限：`chmod +x`
+- 可執行腳本必須有 executable 權限：`chmod +x`
 - 必須有 shebang：`#!/usr/bin/env node`
 
 ### 安全

--- a/skill-src/kiro-telegram-acp/SKILL.md
+++ b/skill-src/kiro-telegram-acp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kiro-telegram-acp
-description: "Relay Telegram /kiro commands to a downstream Kiro agent via OpenClaw hook and ACP. Use when setting up a Telegram-to-Kiro relay, configuring hook-based message routing, or packaging an ACP integration as an OpenClaw skill."
+description: "Relay Telegram /kiro commands to a downstream Kiro agent via OpenClaw hook. Use when setting up a Telegram-to-Kiro relay, configuring hook-based message routing, or packaging an agent integration as an OpenClaw skill."
 homepage: https://github.com/masami-agent/openclaw-kiro-telegram-acp-skill
 metadata:
   {
@@ -37,16 +37,14 @@ Use this chain:
 1. Telegram direct message starts with `/kiro`
 2. OpenClaw hook receives `message:received`
 3. Hook validates channel, chat type, and command prefix
-4. Hook strips `/kiro` and forwards the remaining prompt through a local ACP client or wrapper
-5. The client or wrapper talks to `openclaw acp`, which then calls the target Kiro agent
+4. Hook strips `/kiro` and forwards the remaining prompt via `openclaw agent --message --json`
+5. The agent processes the prompt and returns a JSON response
 6. Hook sends the returned text back to Telegram
 7. Hook cancels the main OpenClaw reply via `message:sending` hook with `{ cancel: true }`
 
 **Important:** In OpenClaw 2026.4.2, `message:received` is a void hook — its return value is discarded. `{ suppress: true }` does **not** work. To prevent the main agent from replying, use a `message:sending` hook that returns `{ cancel: true }`. As a belt-and-suspenders measure, also instruct the main agent in `SOUL.md` to ignore `/kiro` messages.
 
-This skill is documented for OpenClaw `2026.4.2`, where `openclaw acp` is a stdio bridge rather than an HTTP server.
-
-It is also not a one-shot `ask` CLI, so you should document or provide the ACP client or wrapper layer explicitly.
+This skill is documented for OpenClaw `2026.4.2`, using `openclaw agent --message --json` for one-shot agent calls.
 
 ## Implementation Rules
 
@@ -56,7 +54,7 @@ The hook should only do four things:
 
 - detect eligible inbound messages
 - normalize the user prompt
-- call a local ACP client or wrapper
+- call `openclaw agent --message --json` asynchronously
 - send the downstream reply back to Telegram
 
 Do not duplicate business logic, memory, or persona inside the hook unless absolutely necessary.
@@ -90,13 +88,13 @@ After dispatching the background handler, return immediately. Use `message:sendi
 
 ### 5. Handle failures explicitly
 
-On ACP client, wrapper, or Telegram send failure:
+On agent call or Telegram send failure:
 
 - log the error
 - send a short failure notice back to the Telegram chat when possible
 - avoid crashing the hook process
 
-Document pairing and scope approval requirements for ACP usage.
+Document pairing and scope approval requirements.
 
 ## Public Skill Deliverables
 
@@ -105,7 +103,6 @@ When packaging this pattern as a public OpenClaw skill, include:
 - `SKILL.md` with the integration workflow and constraints
 - `references/architecture.md` describing the end-to-end message flow
 - `references/hook-template.ts` with a reusable TypeScript hook example
-- `references/kiro-acp-ask.js` with a minimal working ACP wrapper
 - `references/kiro-agent-template.json` with a sample Kiro agent definition
 - optional public README outside the skill folder if publishing a GitHub repo for humans
 
@@ -121,7 +118,6 @@ Decide all fixed values up front:
 - command prefix: usually `/kiro`
 - target agent name, such as `kiro`
 - response timeout
-- wrapper command name or ACP client invocation
 - failure message format
 
 ### Step 2: Implement the OpenClaw hook
@@ -139,7 +135,7 @@ The handler should:
 3. reject content that does not start with `/kiro`
 4. strip the prefix and trim whitespace
 5. mark the session as pending (for `message:sending` cancellation)
-6. call the local ACP client or wrapper asynchronously (never use `execSync`)
+6. call `openclaw agent --session-id <id> --message <prompt> --json` asynchronously (never use `execSync`)
 7. send the result to Telegram with a `🤖 Kiro` prefix
 
 **Critical:** Do not use `execSync` or any synchronous blocking call inside a hook handler. This will freeze the entire gateway event loop.
@@ -161,10 +157,9 @@ Store stable knowledge in separate markdown files so the Kiro agent can load the
 
 State these explicitly in docs:
 
-- this pattern assumes `openclaw acp` is available locally
-- the hook must have permission to talk to Telegram and invoke the local wrapper or ACP client
-- `openclaw acp` itself is a bridge, not a one-shot request CLI
-- ACP usage may require device pairing and scope approval
+- this pattern assumes `openclaw` CLI is available locally
+- the hook must have permission to talk to Telegram and invoke `openclaw agent`
+- device pairing and scope approval may be required
 - replies are only as safe as the downstream agent prompt and available tools
 - public examples must remove personal bot tokens, user IDs, and private file paths
 
@@ -174,9 +169,7 @@ Read these files when you need concrete examples:
 
 - `references/architecture.md` for a concise architecture summary
 - `references/deployment.md` for deployment steps and troubleshooting
-- `references/wrapper-contract.md` for the stdout/stderr contract expected by the hook
 - `references/hook-template.ts` for a reusable OpenClaw hook example
-- `references/kiro-acp-ask.js` for the minimal working ACP wrapper
 - `references/kiro-agent-template.json` for a sample Kiro agent definition
 
 ## Validation Checklist
@@ -186,31 +179,30 @@ Before publishing or reusing the pattern, verify:
 - `/kiro hello` produces one Telegram reply, not two
 - non-`/kiro` messages do not trigger the hook
 - empty `/kiro` returns a usage hint
-- ACP timeout produces a readable error
+- agent timeout produces a readable error
 - pairing failures point users to approval steps
 - all personal secrets, IDs, and local paths are replaced with placeholders in public docs
 
 ## Alternative Designs
 
-### Option A: OpenClaw hook -> ACP client/wrapper -> `openclaw acp` -> Kiro agent
+### Option A: OpenClaw hook -> `openclaw agent --message --json`
 
 Use this as the default recommendation for OpenClaw `2026.4.2`.
 
 Pros:
 
-- correct for current transport behavior
+- simple one-shot CLI call
 - keeps the hook logic simple
 - good separation between routing and agent behavior
 
 Cons:
 
-- depends on local OpenClaw ACP availability
-- requires an extra wrapper/client component
+- depends on local OpenClaw CLI availability
 - requires pairing and scope approval in some environments
 
-### Option B: OpenClaw hook -> custom HTTP wrapper -> `openclaw acp` -> Kiro agent
+### Option B: OpenClaw hook -> custom HTTP wrapper -> agent
 
-Use when you intentionally provide your own local HTTP layer on top of ACP.
+Use when you intentionally provide your own local HTTP layer.
 
 Pros:
 
@@ -222,15 +214,8 @@ Cons:
 - adds another component to maintain
 - should not be presented as the default OpenClaw behavior
 
-### Option C: Direct CLI execution from a hook
+### Option C: OpenClaw hook -> ACP stdio bridge -> agent
 
-Avoid unless ACP is unavailable.
-
-Cons:
-
-- weaker isolation
-- harder error handling
-- more fragile process management
-- higher chance of duplicated logic
+Avoid. In OpenClaw 2026.4.2, the ACP bridge routes replies to the chat channel instead of returning them to the stdio client. Not suitable for hook use cases.
 
 Recommendation: prefer Option A for a public starter pattern on current OpenClaw builds.

--- a/skill-src/kiro-telegram-acp/references/deployment.md
+++ b/skill-src/kiro-telegram-acp/references/deployment.md
@@ -92,14 +92,11 @@ Your Telegram hook usually wants a one-shot request/response function. `openclaw
 You therefore need one of these:
 
 - a local ACP client that can send a single prompt through `openclaw acp`
-- a small wrapper process that speaks ACP over stdio and returns final text
-
-The example hook in this repo uses a placeholder wrapper command so the integration shape is correct without pretending `openclaw acp ask` exists.
+The hook uses `openclaw agent --session-id <id> --message <prompt> --json` for one-shot agent calls.
 
 Start from:
 
-- `examples/kiro-acp-ask.js`
-- `docs/wrapper-contract.md`
+- `examples/hook-template.ts`
 
 ## Step 5: Approve pairing and ACP scopes
 

--- a/src/hook/__tests__/handler.test.ts
+++ b/src/hook/__tests__/handler.test.ts
@@ -125,9 +125,9 @@ describe("Hook Handler", () => {
     vi.restoreAllMocks();
   });
 
-  // ── /kiro message triggers ACP Wrapper call ───────────────
-  describe("/kiro message triggers ACP Wrapper call", () => {
-    it("should use execFile to call ACP Wrapper with correct arguments", async () => {
+  // ── /kiro message triggers agent call ───────────────
+  describe("/kiro message triggers agent call", () => {
+    it("should use execFile to call agent with correct arguments", async () => {
       const event = createEvent({
         context: { content: "/kiro what is TypeScript?" },
       });
@@ -146,7 +146,7 @@ describe("Hook Handler", () => {
       expect(args).toContain("--json");
     });
 
-    it("should send ACP Wrapper stdout reply to Telegram", async () => {
+    it("should send agent stdout reply to Telegram", async () => {
       mockExecFileSuccess("This is the Kiro reply");
 
       const event = createEvent();
@@ -172,7 +172,7 @@ describe("Hook Handler", () => {
       handler(event);
       await flushPromises();
 
-      // Should not call ACP Wrapper
+      // Should not call agent
       expect(mockExecFile).not.toHaveBeenCalled();
 
       // Should send usage message
@@ -181,7 +181,7 @@ describe("Hook Handler", () => {
       expect(body.text).toContain("Usage:");
     });
 
-    it("ACP Wrapper error should be processed through Error Formatter and send a friendly message", async () => {
+    it("agent error should be processed through Error Formatter and send a friendly message", async () => {
       mockExecFileError(3, "timeout after 120000ms");
 
       const event = createEvent();
@@ -197,7 +197,7 @@ describe("Hook Handler", () => {
 
   // ── Non-/kiro messages should not trigger processing ──────
   describe("Non-/kiro messages should not trigger processing", () => {
-    it("regular messages should not trigger ACP Wrapper", () => {
+    it("regular messages should not trigger agent", () => {
       const event = createEvent({
         context: { content: "hello world" },
       });

--- a/src/hook/handler.ts
+++ b/src/hook/handler.ts
@@ -205,7 +205,7 @@ function extractChatId(event: OpenClawEvent): string {
 // ============================================================
 
 /**
- * 處理 /kiro 指令：呼叫 ACP Wrapper 並傳送回覆至 Telegram。
+ * Handle /kiro command: call agent and send reply to Telegram.
  */
 async function handleKiroQuery(chatId: string, query: string, sessionId: string): Promise<void> {
   try {
@@ -302,7 +302,7 @@ async function handleKiroQuery(chatId: string, query: string, sessionId: string)
  *
  * message:received（void hook）：
  *   驗證 channel、chatId、/kiro prefix → markSession()（同步）
- *   → getKiroSessionId() → execFile 呼叫 ACP Wrapper → Error Formatter → Telegram
+ *   → getKiroSessionId() → execFile calls agent → Error Formatter → Telegram
  *
  * message:sending（可回傳 { cancel: true }）：
  *   shouldCancel() 檢查是否需取消主 agent 回覆
@@ -353,7 +353,7 @@ const handler = (event: OpenClawEvent): void | { cancel: true } => {
     return;
   }
 
-  // 非同步呼叫 ACP Wrapper（不阻塞 gateway event loop）
+  // Async agent call (non-blocking gateway event loop)
   void handleKiroQuery(chatId, query, kiroSessionId);
 };
 

--- a/src/lib/acp-error-handler.ts
+++ b/src/lib/acp-error-handler.ts
@@ -16,7 +16,7 @@ import type { AcpErrorResult } from "../types/index.js";
  *
  * In all cases, the full raw error is logged to stderr.
  *
- * @param rawError - Raw error message returned by the ACP Wrapper
+ * @param rawError - Raw error message returned by the agent call
  * @returns AcpErrorResult containing identification result, user message, and fix suggestions
  */
 export function handleAcpError(rawError: string): AcpErrorResult {

--- a/src/lib/error-formatter.ts
+++ b/src/lib/error-formatter.ts
@@ -110,10 +110,10 @@ function truncateMessage(message: string, maxLength: number = MAX_USER_MESSAGE_L
 }
 
 /**
- * Parse ACP Wrapper stdout/stderr output, identify error type, and format.
+ * Parse agent stdout/stderr output, identify error type, and format.
  *
- * @param rawOutput - Raw output from the ACP Wrapper (stdout + stderr)
- * @param exitCode - ACP Wrapper exit code (0=success, 1=usage, 2=connection failure, 3=timeout)
+ * @param rawOutput - Raw output from the agent call (stdout + stderr)
+ * @param exitCode - Agent exit code (0=success, 1=usage, 2=connection failure, 3=timeout)
  * @returns FormattedError containing user message, debug message, and error classification
  */
 export function formatError(rawOutput: string, exitCode: number): FormattedError {

--- a/src/lib/reply-suppressor.ts
+++ b/src/lib/reply-suppressor.ts
@@ -57,7 +57,7 @@ function purgeExpired(): void {
  * Mark a session as pending (called during the message:received phase).
  *
  * This is a synchronous operation to ensure the mark is set before any async
- * operations (such as ACP Wrapper calls), preventing the message:sending hook
+ * operations (such as agent calls), preventing the message:sending hook
  * from missing the cancel signal due to timing issues.
  */
 export function markSession(sessionKey: string): void {

--- a/src/lib/session-isolator.ts
+++ b/src/lib/session-isolator.ts
@@ -40,7 +40,7 @@ export function getIsolationLimitations(): string[] {
       "/kiro message content may still be visible to the main agent.",
     "It is recommended to add a directive in SOUL.md instructing the main agent to ignore messages starting with /kiro, " +
       "as a supplementary measure to hook-level isolation.",
-    "Sessions may disappear after kiro-cli restarts. The ACP Wrapper needs to handle the case where a session does not exist " +
+    "Sessions may disappear after kiro-cli restarts. The agent call needs to handle the case where a session does not exist " +
       "(automatically rebuild via acp/createSession).",
     "Kiro sessions across different Telegram chats are isolated, but all /kiro messages within the same chat " +
       "share a single session (by design, for cross-message memory).",


### PR DESCRIPTION
Follow-up to PR #16. Resolves merge conflicts with English translation PRs (#10-#14) and removes all remaining ACP wrapper references that were missed.

### Changes
- Remove all `ACP Wrapper` text references from comments and docs
- Update SKILL.md to document `openclaw agent --message --json` approach
- Update masami-steering.md to remove kiro-acp-ask sync rules
- Update deployment.md reference to use hook-template.ts
- Update INSTALL.md health checker list (remove wrapper check)
- Update INSTALL.md SOUL.md section to recommend `no_reply` token

### Verification
- `npm run build` — clean
- `npx vitest --run` — 85 tests pass (6 files)